### PR TITLE
Changing the detail link to Bungie.net

### DIFF
--- a/src/components/Item/index.js
+++ b/src/components/Item/index.js
@@ -67,7 +67,7 @@ export default class Item extends Component {
   render() {
     const { className, onClick, item, dev, small, tiny } = this.props;
 
-    const dtrLink = `http://db.destinytracker.com/d2/en/items/${item.hash}`;
+    const dtrLink = `https://www.bungie.net/en/Explore/Detail/Item/${item.hash}`;
 
     const dtrProps = {
       href: dtrLink,


### PR DESCRIPTION
The links to Destiny Tracker is not working. My suggestion is linking it directly to Bungie.