### PR TITLE
Mercury destination emblem

### DIFF
--- a/src/setData/dlc1.js
+++ b/src/setData/dlc1.js
@@ -816,6 +816,7 @@ module.exports = [
             items: [
               4132147351, // Recurrent Resplendence
               4182480235, // Hellspawn
+              1940590825, // Sonic Simulation
             ],
           },
           {

--- a/src/setData/dlc1.js
+++ b/src/setData/dlc1.js
@@ -450,7 +450,7 @@ module.exports = [
             ],
           },
           {
-            title: 'Achievement Emblems - Curse of Osiris',
+            title: 'Achievement Emblems',
             items: [
               2939572586, // Hero of the Infinite
               4261480749, // Prophetic Arsenal

--- a/src/setData/dlc1.js
+++ b/src/setData/dlc1.js
@@ -817,6 +817,7 @@ module.exports = [
               4132147351, // Recurrent Resplendence
               4182480235, // Hellspawn
               1940590825, // Sonic Simulation
+              1940590823, // Carrhae
             ],
           },
           {

--- a/src/setData/dlc1.js
+++ b/src/setData/dlc1.js
@@ -442,13 +442,18 @@ module.exports = [
             ],
           },
           {
-            title: 'Achievement Emblems',
+            title: 'Emblems',
+            items: [
+              1312472209, // Fields of Mercury
+            ],
+          },
+          {
+            title: 'Achievement Emblems - Curse of Osiris',
             items: [
               2939572586, // Hero of the Infinite
               2939572584, // Secrets of the Vex (Emblem)
               2939572585, // Vex Destroyer (Emblem)
               2939572590, // Vex Scholar (Emblem)
-              2939572578, // Mercury Treasure Seeker
               2939572589, // Crossroads Emblem
               4261480748, // Transit of Mercury
             ],

--- a/src/setData/dlc1.js
+++ b/src/setData/dlc1.js
@@ -444,18 +444,19 @@ module.exports = [
           {
             title: 'Emblems',
             items: [
-              1312472209, // Fields of Mercury
+              1312472209, // Fields of Glass
+              2939572589, // Crossroads Emblem
+              4261480748, // Transit of Mercury
             ],
           },
           {
             title: 'Achievement Emblems - Curse of Osiris',
             items: [
               2939572586, // Hero of the Infinite
+              4261480749, // Prophetic Arsenal
               2939572584, // Secrets of the Vex (Emblem)
               2939572585, // Vex Destroyer (Emblem)
               2939572590, // Vex Scholar (Emblem)
-              2939572589, // Crossroads Emblem
-              4261480748, // Transit of Mercury
             ],
           },
         ],


### PR DESCRIPTION
- Replace Mercury Treasure Seeker with Fields of Glass
- Add missing Prophetic Arsenal
- Split public space emblems from achievement emblems
- Add Sonic Simulation to promotional section despite it being classified