### PR TITLE
Add normal Trials ornaments; differentiate from flawless ornaments

### DIFF
--- a/src/setData/dlc1.js
+++ b/src/setData/dlc1.js
@@ -169,35 +169,64 @@ module.exports = [
               2071412133 // A Cold Sweat
             ]
           },
-
           {
-            title: 'Hunter ornaments',
+            title: 'Hunter Ornaments',
             items: [
-              3000782857, // Trials Prestige Ornament
-              3907623580, // Trials Prestige Ornament
-              1480689066, // Trials Prestige Ornament
-              3491371766, // Trials Prestige Ornament
-              85546655 // Trials Prestige Ornament
+              1698264996, // Trials Head Ornament
+              4155106369, // Trials Arms Ornament
+              3799317511, // Trials Chest Ornament
+              1254742579, // Trials Legs Ornament
+              1475681954  // Trials Class Ornament
             ]
           },
           {
-            title: 'Titan ornaments',
+            title: 'Hunter Flawless Ornaments',
             items: [
-              3042323431, // Trials Prestige Ornament
-              1309834898, // Trials Prestige Ornament
-              3047754372, // Trials Prestige Ornament
-              3675824124, // Trials Prestige Ornament
-              1717767197 // Trials Prestige Ornament
+              3000782857, // Trials Prestige Head Ornament
+              3907623580, // Trials Prestige Arms Ornament
+              1480689066, // Trials Prestige Chest Ornament
+              3491371766, // Trials Prestige Legs Ornament
+              85546655 // Trials Prestige Class Ornament
             ]
           },
           {
-            title: 'Warlock ornaments',
+            title: 'Titan Ornaments',
             items: [
-              2338851618, // Trials Prestige Ornament
-              4105027183, // Trials Prestige Ornament
-              2666197459, // Trials Prestige Ornament
-              3026479209, // Trials Prestige Ornament
-              2394332958 // Trials Prestige Ornament
+              62776458,   // Trials Head Ornament
+              2194111759, // Trials Arms Ornament
+              3647777257, // Trials Chest Ornament
+              3964883617, // Trials Legs Ornament
+              4275895304  // Trials Class Ornament
+            ]
+          },
+          {
+            title: 'Titan Flawless Ornaments',
+            items: [
+              3042323431, // Trials Prestige Head Ornament
+              1309834898, // Trials Prestige Arms Ornament
+              3047754372, // Trials Prestige Chest Ornament
+              3675824124, // Trials Prestige Legs Ornament
+              1717767197 // Trials Prestige Class Ornament
+            ]
+          },
+          {
+            title: 'Warlock Ornaments',
+            items: [
+              948716319,  // Trials Head Ornament
+              2984392562, // Trials Arms Ornament
+              607756182,  // Trials Chest Ornament
+              2426456324, // Trials Legs Ornament
+              3828657371  // Trials Class Ornament
+            ]
+          },
+          {
+            title: 'Warlock Flawless Ornaments',
+            items: [
+              2338851618, // Trials Prestige Head Ornament
+              4105027183, // Trials Prestige Arms Ornament
+              2666197459, // Trials Prestige Chest Ornament
+              3026479209, // Trials Prestige Legs Ornament
+              2394332958 // Trials Prestige Class Ornament
             ]
           }
         ]


### PR DESCRIPTION
Add the "normal" Trials ornaments as they have different unlock requirements than the Prestige ornaments; namely prestige ornaments requires flawless runs and increased number of kills.