### PR TITLE
Revert "Iron Banner S3 Exotic Emote"

### DIFF
--- a/src/setData/dlc2.js
+++ b/src/setData/dlc2.js
@@ -144,7 +144,6 @@ module.exports = [
           {
             name: 'Extras',
             items: [
-              253898492, //Salute of the Lords
               1420718398, // Esfera Triumph
               1069214754, // Visage of Skorri
               3449099425 // Iron to Steel 


### PR DESCRIPTION
Reverts joshhunt/destinySets#109

Bungie confirmed it's only available from Eververse and not tied to Iron Banner. 

https://www.reddit.com/r/DestinyTheGame/comments/8lcd9o/thank_you_for_letting_me_do_a_direct_purchase_of/dzel5ef/