### PR TITLE
Korean Localization

### DIFF
--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -56,6 +56,11 @@ export const CHINESE = {
   name: 'Chinese'
 };
 
+export const KOREAN = {
+  code: 'ko',
+  name: 'Korean'
+}
+
 export const DEFAULT_LANG = ENGLISH;
 
 export const languages = [
@@ -69,7 +74,8 @@ export const languages = [
   SPANISH_LATIN,
   RUSSIAN,
   POLISH,
-  CHINESE
+  CHINESE,
+  KOREAN
 ];
 
 export const languageByCode = keyBy(languages, lang => lang.code);


### PR DESCRIPTION
Added support for the Korean manifest. This is in response to issue #150 

I also noticed that changing languages requires a manual refresh before it tries to load the new manifest. I did not address that in this pull request but I'll make an issue.