### PR TITLE
Add Ghost Projections

### DIFF
--- a/src/lib/destinyEnums.js
+++ b/src/lib/destinyEnums.js
@@ -26,6 +26,7 @@ export const WEAPON = 1;
 export const EMBLEM = 19;
 export const ARMOR = 20;
 export const GHOST = 39;
+export const GHOST_PROJECTION = 1404791674;
 export const SHADER = 41;
 export const SHIP = 42;
 export const SPARROW = 43;

--- a/src/lib/fancySearch.js
+++ b/src/lib/fancySearch.js
@@ -19,6 +19,7 @@ const COLLECTABLE = [
   enums.WEAPON,
   enums.ARMOR,
   enums.GHOST,
+  enums.GHOST_PROJECTION,
   enums.SPARROW,
   enums.SHIP,
   enums.SHADER,
@@ -80,14 +81,23 @@ export const fancySearchFns = {
       const categories = item.itemCategoryHashes || [];
       return (
         categories.includes(enums.ARMOR) ||
-        categories.includes(enums.WEAPON) ||
-        categories.includes(enums.GHOST)
+        categories.includes(enums.WEAPON)
       );
     });
   },
 
   'is:ghost': items => {
     return itemFilter(items, itemCategory(enums.GHOST));
+  },
+
+  'is:ghostprojection': items => {
+    return itemFilter(items, itemCategory(enums.GHOST_PROJECTION));
+  },
+
+  'is:ghostly': items => {
+    return itemFilter(items, item => {
+      return itemCategory(enums.GHOST)(item) || itemCategory(enums.GHOST_PROJECTION)(item);
+    });
   },
 
   'is:sparrow': items => {

--- a/src/lib/sortItemsIntoSections.js
+++ b/src/lib/sortItemsIntoSections.js
@@ -7,6 +7,7 @@ import {
   WEAPON,
   ARMOR,
   GHOST,
+  GHOST_PROJECTION,
   EMOTES,
   SHIP,
   SPARROW,
@@ -104,6 +105,8 @@ export default function sortItems(_items, verbose = false) {
       return 'weapon';
     } else if (item.itemCategoryHashes.includes(GHOST)) {
       return 'ghosts';
+    } else if (item.itemCategoryHashes.includes(GHOST_PROJECTION)) {
+      return 'ghostProjections';
     } else if (item.itemCategoryHashes.includes(EMOTES)) {
       return 'emotes';
     } else if (item.itemCategoryHashes.includes(SHIP)) {
@@ -148,6 +151,7 @@ export default function sortItems(_items, verbose = false) {
     },
     { name: 'Emotes', items: sectionItems.emotes },
     { name: 'Ghosts', items: sectionItems.ghosts },
+    { name: 'Ghost Projections', items: sectionItems.ghostProjections },
     { name: 'Ships', items: sectionItems.ships },
     { name: 'Sparrows', items: sectionItems.sparrows },
     { name: 'Emblems', items: sectionItems.emblems },

--- a/src/setData/allItems.js
+++ b/src/setData/allItems.js
@@ -30,10 +30,6 @@ export default ([
             name: 'Power',
             query: 'is:legendary is:weapon is:power'
           },
-          {
-            name: 'Ghosts',
-            query: 'is:legendary is:ghost'
-          }
         ]
       },
       {
@@ -42,7 +38,14 @@ export default ([
         big: true,
         query: 'is:legendary is:armor',
         sections: []
-      }
+      },
+      {
+        name: 'Ghosts',
+        id: 'ALL_GHOSTS',
+        big: true,
+        query: 'is:ghostly',
+        sections: []
+      },
     ]
   },
 

--- a/src/setData/yearTwo.js
+++ b/src/setData/yearTwo.js
@@ -690,6 +690,24 @@ export default ([
             ]
           },
           {
+            name: 'Ghost Projections',
+            season: 4,
+            items: [
+              3148574213, // Horned Horse Projection
+              3148574212, // Sovereign Projection
+              3148574215, // Fortunate Projection
+              3148574214, // Jeweled Projection
+              3148574209, // Beastly Projection
+              3148574208, // Vanguard Projection
+              3148574211, // Crucible Projection
+              3148574210, // Jade Rabbit Projection
+              3148574221, // SUROS Projection
+              3148574220, // Häkke Projection
+              1927164028, // Electrostatic Projection
+              1927164029  // Tex Mechanica Projection
+            ]
+          },
+          {
             name: 'Ships',
             season: 4,
             items: [


### PR DESCRIPTION
This adds the new ghost projection mods from Eververse. The items have been added to yearTwo as a list and a searchable category and grouping added to the libraries. For the all items page there wasn't really a great place to slot these in so I created a new ghosts section and merged the existing ghost on the page into it. This seems consistent with how sparrows and ships are handled but I kept them under the gear category.

Note: None of these changes are tested, I looked over the code and duplicated other similar items as close as possible so I think it should be good. Tried to get the code to run but I believe with the addition of the fontawesome-pro libraries it's impossible to run now without a license to that?