### PR TITLE
Update Login Call to Action

### DIFF
--- a/src/components/CTA/index.js
+++ b/src/components/CTA/index.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import classNames from 'classnames';
+import styles from './styles.styl';
+
+export default function CTA({ children, className, ...props }) {
+  return (
+    <a {...props} className={classNames(styles.cta, className)}>
+      {children}
+    </a>
+  );
+}

--- a/src/components/CTA/styles.styl
+++ b/src/components/CTA/styles.styl
@@ -1,0 +1,11 @@
+.cta
+  color: black !important
+  background: rgba(208, 170, 11, 1.0)
+  padding: 10px 20px
+  text-decoration: none
+  transition: 150ms ease-in-out
+  display: inline-block
+  text-align: center
+
+  &:hover
+    background: #ffce1f

--- a/src/components/Dismissable/index.js
+++ b/src/components/Dismissable/index.js
@@ -9,7 +9,13 @@ export default class Dismissable extends Component {
     active: true
   };
 
-  toggle = () => this.setState({ active: !this.state.active });
+  toggle = e => {
+    if (this.props.onDismissed) {
+      this.props.onDismissed(e);
+    }
+
+    this.setState(prev => ({ active: !prev.active }));
+  };
 
   render() {
     if (!this.state.active) {

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -12,6 +12,7 @@ import logo from 'app/logo.svg';
 import xur from 'app/assets/xur_icon.png';
 import { DONATION_LINK } from 'app/components/DonateButton';
 import Icon from 'app/components/Icon';
+import LoginCTA from '../LoginCTA';
 import DonateButton from 'app/components/DonateButton';
 import ProfileDropdown from './ProfileDropdown';
 import LanguageDropdown from './LanguageDropdown';
@@ -113,6 +114,7 @@ function sidebarClickOutside(toggleSidebar, isOpen, ev) {
 }
 
 function Sidebar({
+  isAuth,
   isOpen,
   language,
   setLanguage,
@@ -151,7 +153,8 @@ function Sidebar({
             setLanguage={setLanguage}
           />
         )}
-        <br />
+
+        {!isAuth && <LoginCTA className={styles.sidebarLoginCta} />}
 
         <div className={styles.sidebarExtra}>
           <DonateButton />
@@ -203,6 +206,7 @@ export default class Header extends Component {
       currentProfile,
       allProfiles,
       switchProfile,
+      isAuth,
       language,
       setLanguage,
       logout,
@@ -245,6 +249,10 @@ export default class Header extends Component {
 
           <SiteName />
 
+          {/* isOverflowing && (
+            <LoginCTA className={styles.headerLoginCta}>Connect</LoginCTA>
+          ) */}
+
           <div className={styles.links} ref={this.setLinksRef}>
             <SiteLinks
               displayXur={displayXur}
@@ -253,6 +261,11 @@ export default class Header extends Component {
               showDataExplorerLink={showDataExplorerLink}
             />
           </div>
+
+          {!isAuth &&
+            !isOverflowing && <LoginCTA className={styles.headerLoginCta} />}
+
+          <div className={styles.spacer} />
 
           <div className={styles.etc}>
             {language &&

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -249,10 +249,6 @@ export default class Header extends Component {
 
           <SiteName />
 
-          {/* isOverflowing && (
-            <LoginCTA className={styles.headerLoginCta}>Connect</LoginCTA>
-          ) */}
-
           <div className={styles.links} ref={this.setLinksRef}>
             <SiteLinks
               displayXur={displayXur}

--- a/src/components/Header/styles.styl
+++ b/src/components/Header/styles.styl
@@ -34,12 +34,14 @@ $height = 52px
   margin-right: 12px
 
 .links
-  flex: 1
   margin-left: $padding
   height: $height
   overflow: hidden
   display: flex
   flex-wrap: wrap
+
+.spacer
+  flex: 1
 
 .link
 .dummyLink
@@ -94,6 +96,10 @@ $height = 52px
   margin: 0 -8px
   display: flex
   align-items: center
+
+.headerLoginCta
+  margin-left: 16px
+  padding: 10px 32px;
 
 .socialLink
   display: inline-block
@@ -165,6 +171,10 @@ $height = 52px
 
   .socialLink
     display: inline-block !important
+
+  .sidebarLoginCta
+    margin: 12px auto 8px;
+    display: block;
 
   .link
     display: block !important // override media query

--- a/src/components/LoginCTA/index.js
+++ b/src/components/LoginCTA/index.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { authUrl } from 'app/lib/destinyAuth';
+import CTA from '../CTA';
+
+export default function LoginCTA({ children, ...props }) {
+  return (
+    <CTA {...props} href={authUrl()}>
+      {children || 'Connect Bungie.net'}
+    </CTA>
+  );
+}

--- a/src/components/LoginUpsell/index.js
+++ b/src/components/LoginUpsell/index.js
@@ -1,17 +1,15 @@
 import React from 'react';
 
-import { authUrl } from 'app/lib/destinyAuth';
-
 import styles from './styles.styl';
+import LoginCTA from '../LoginCTA';
+import Dismissable from '../Dismissable';
 
-export default function LoginUpsell({ children }) {
+export default function LoginUpsell({ children, ...props }) {
   return (
-    <div className={styles.root}>
+    <Dismissable {...props} className={styles.root}>
       {children && <div className={styles.children}>{children}</div>}
 
-      <a className={styles.authLink} href={authUrl()}>
-        Connect Bungie.net
-      </a>
-    </div>
+      <LoginCTA />
+    </Dismissable>
   );
 }

--- a/src/components/LoginUpsell/styles.styl
+++ b/src/components/LoginUpsell/styles.styl
@@ -11,14 +11,3 @@
 
 .children
   margin-bottom: 20px
-
-.authLink
-  color: black !important
-  background: rgba(208, 170, 11, 1.0)
-  padding: 10px 20px
-  text-decoration: none
-  transition: 150ms ease-in-out
-  display: inline-block
-
-  &:hover
-    background: #ffce1f

--- a/src/views/App/index.js
+++ b/src/views/App/index.js
@@ -41,6 +41,8 @@ const MANIFEST_MESSAGES = {
   [STATUS_UNZIPPING]: 'Unzipping item data...'
 };
 
+const hasDismissedCookie = /dismissed_login_upsell/.test(document.cookie);
+
 class App extends Component {
   state = {};
   alreadyFetched = false;
@@ -134,6 +136,11 @@ class App extends Component {
     });
   };
 
+  handleDismissLoginUpsell = () => {
+    // Set a cookie to set the dismissed state. Clear after 3 days.
+    document.cookie = 'dismissed_login_upsell=true; path=/; max-age=259200;';
+  };
+
   switchProfile = profile => {
     const { membershipId, membershipType } = profile.profile.data.userInfo;
     ls.savePreviousAccount(membershipId, membershipType);
@@ -179,10 +186,10 @@ class App extends Component {
 
     const messages = [];
 
-    if (!auth.isAuthed) {
+    if (!hasDismissedCookie && !auth.isAuthed) {
       messages.push(
         <div className={styles.auth}>
-          <LoginUpsell>
+          <LoginUpsell onDismissed={this.handleDismissLoginUpsell}>
             {profile
               ? 'The connection with Bungie has expired. Please reconnect to update your inventory.'
               : `Connect your Bungie.net acccount to automatically track items you've collected and dismantled.`}
@@ -234,6 +241,7 @@ class App extends Component {
         <Header
           profileLoading={profileLoading}
           profileCached={profileCached}
+          isAuth={auth.isAuthed}
           authExpired={!auth.isAuthed && profile}
           currentProfile={profile}
           allProfiles={allProfiles}


### PR DESCRIPTION
## Purpose
Allow the Login Upsell panel to be dismissable, and return 3 days later (handled via cookie).

I feel that a permanent, persistent panel consuming 27% of the screen height (on a Pixel 2) is a bad UX pattern. Allowing the panel to be dismissed should allow the user to see more content, and reduce potential friction.

## What's new
* Made the Login Upsell component dismissable
  * Added `onDismissed` callback to the `Dismissable` component
* Create a cookie "dismissed_login_upsell" with `max-age` of 3 days after dismissing Login Upsell
  * This cookie is only checked once, on App mount
  * The existence of this cookie hides the Login Upsell component
* Added a new Login CTA to the desktop header
* Added a new Login CTA to the mobile sidebar