### PR TITLE
Update PlayStation exclusives list

### DIFF
--- a/src/extraData/consoleExclusives.js
+++ b/src/extraData/consoleExclusives.js
@@ -1,37 +1,24 @@
 module.exports = {
   ps4: [
-    155832748, // Icarus Drifter Mask
-    1847870034, // Icarus Drifter Cape
-    3066593211, // Icarus Drifter Vest
-    3569443559, // Icarus Drifter Legs
-    3646674533, // Icarus Drifter Grips
-    690335398, // Terra Concord Helm
-    1512829977, // Terra Concord Greaves
-    3291075521, // Terra Concord Plate
-    3999262583, // Terra Concord Fists
-    4073580572, // Terra Concord Mark
-    2728535008, // Tesseract Trace IV
-    2811180959, // Tesseract Trace IV
-    3169402598, // Tesseract Trace IV
-    4092393610, // Tesseract Trace IV
-    434243995, // Hodiocentrist Bond
-    3141979347, // Borealis
-    2503134033, // City Apex ship
+    3994031968, // Red Moon Phantom Mask
+    1601578801, // Red Moon Phantom Grips
+    3612275815, // Red Moon Phantom Vest
+    1432831619, // Red Moon Phantom Steps
+    32806262,   // Cloak of Five Full Moons
 
-    1680657538, // Insight Rover Mask
-    1020198891, // Insight Rover Grips
-    369384485, // Insight Rover Vest
-    2111956477, // Insight Rover Boots
-    3786300792, // Clandestine Maneuvers
-    1192751404, // Insight Unyielding Helm
-    388625893, // Insight Unyielding Gauntlets
-    2185500219, // Insight Unyielding Plate
-    311394919, // Insight Unyielding Greaves
-    966777042, // Anti-Hero Victory
-    2905154661, // Insight Vikti Hood
-    3685831476, // Insight Vikti Gloves
-    731888972, // Insight Vikti Robes
-    3973570110, // Insight Vikti Boots
-    3430647425 // Synaptic Construct
+    3839471140, // Mimetic Savior Helm
+    3403784957, // Mimetic Savior Gauntlets
+    3066154883, // Mimetic Savior Plate
+    1432969759, // Mimetic Savior Greaves
+    1964977914, // Mimetic Savior Bond
+
+    2470746631, // Thorium Holt Hood
+    417345678,  // Thorium Holt Gloves
+    1330107298, // Thorium Holt Robes
+    2924984456, // Thorium Holt Boots
+    554000115,  // Thorium Holt Bond
+
+    1852863732, // Wavesplitter
+    1673638926  // The Great Beyond
   ]
 };


### PR DESCRIPTION
List of year two exclusives taken from [PlayStation Blog][blog]. Removed all year one exclusives as they should all be available now on Xbox/PC as per this [Activision post][activision].

Fixes #164.

[blog]: https://blog.us.playstation.com/2018/08/30/destiny-2-forsaken-playstation-exclusive-content-detailed/
[activision]: https://blog.activision.com/t5/Destiny/Announcing-Forsaken-The-First-Major-Expansion-For-Destiny-2/ba-p/10745557