### PR TITLE
Use breadcrumb ids for link prefix - Fixes #172

### DIFF
--- a/src/views/Triumphs/index.js
+++ b/src/views/Triumphs/index.js
@@ -54,7 +54,7 @@ class Triumphs extends Component {
           <PresentationNodeChildren
             hash={viewCrumb.id}
             showChildren={true}
-            linkPrefix={`/${breadcrumbs.join('/')}`}
+            linkPrefix={`/${breadcrumbs.map(bc => bc.id).join('/')}`}
           />
         </div>
       );


### PR DESCRIPTION
link prefix was being created by joining breadcrumb objects resulting in [object Object]/[object Object] string. Fixed by mapping breadcrumbs to the breadcrumb id. Fix for #172 