### PR TITLE
Map socket's plugHash to an array of reusablePlugs for sockets on items that do not have reusablePlugs (curated rolls)

### DIFF
--- a/src/views/ItemPage/index.js
+++ b/src/views/ItemPage/index.js
@@ -221,9 +221,12 @@ function mapStateToProps() {
             socketCategory &&
             socketCategory.socketIndexes.map(socketIndex => {
               const socket = instance.$sockets[socketIndex];
+              const reusablePlugs = socket.reusablePlugs || [{
+                plugItemHash: socket.plugHash,
+              }];
               return {
                 // mainPerk: itemDefs[socket.plugHash],
-                altPerks: socket.reusablePlugs.map(plug => ({
+                altPerks: reusablePlugs.map(plug => ({
                   enabled: socket.plugHash === plug.plugItemHash,
                   plugItem: itemDefs[plug.plugItemHash]
                 }))


### PR DESCRIPTION
Fixes #194 