### PR TITLE
Blacklist based off of itemCategoryHashes

### DIFF
--- a/src/views/Inventory/selectors.js
+++ b/src/views/Inventory/selectors.js
@@ -35,6 +35,7 @@ const ITEM_BLACKLIST = [
   2896466320, // Jade Rabbit dupe
   2978016230, // Jade Rabbit dupe
   3229272315, // Jade Rabbit dupe
+  2146650065, // Prometheus Lens dupe
   2251716886, // Jade Rabbit ornament
   2769834047, // Old emblems
   3334815691, // Old emblems

--- a/src/views/Inventory/selectors.js
+++ b/src/views/Inventory/selectors.js
@@ -30,13 +30,6 @@ import { default as sortItems } from 'app/lib/sortItemsIntoSections';
 
 const ITEM_BLACKLIST = [
   1744115122, // Legend of Acrius quest item
-  460724140, // Jade Rabbit dupe
-  546372301, // Jade Rabbit dupe
-  2896466320, // Jade Rabbit dupe
-  2978016230, // Jade Rabbit dupe
-  3229272315, // Jade Rabbit dupe
-  2146650065, // Prometheus Lens dupe
-  2251716886, // Jade Rabbit ornament
   2769834047, // Old emblems
   3334815691, // Old emblems
   3754910498, // Old emblems
@@ -135,7 +128,10 @@ function query(
     checklist: checklistDefsArray,
     presentationNodeDefs
   }).filter(item => {
-    return !ITEM_BLACKLIST.includes(item.hash);
+    return (
+      !ITEM_BLACKLIST.includes(item.hash) &&
+      !item.itemCategoryHashes.includes(3109687656)
+    );
   });
 
   return (results || []).filter(Boolean);


### PR DESCRIPTION
Can probably handle this better by ignoring all itemCategoryHash `Dummies`

https://data.destinysets.com/i/InventoryItem:2146650065/ItemCategory:3109687656

Closes #223