### PR TITLE
windows path support in loader

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -12,7 +12,7 @@ module.exports = function override(config, env) {
   config.entry.unshift('babel-polyfill');
 
   const babelLoader = getLoader(config.module.rules, rule => {
-    return rule.loader && rule.loader.includes('/babel-loader/');
+    return rule.loader && /[\/\\]babel-loader[\/\\]/.test(rule.loader);
   });
 
   babelLoader.include = [


### PR DESCRIPTION
uses either type of slash. voila destinysets boots in windows :tada: 