### PR TITLE
Shadowkeep + Season 8

### DIFF
--- a/src/AppRouter.js
+++ b/src/AppRouter.js
@@ -23,7 +23,9 @@ export default class AppRouter extends Component {
           <Route component={App}>
             <Route path="/solstice-2019" component={SolsticeOfHeroes} />
 
-            <Route path="/" component={Inventory} setData={sets.yearTwo} />
+            <Route path="/" component={Inventory} setData={sets.yearThree} />
+
+            <Route path="/base" component={Inventory} setData={sets.baseGame} />
 
             <Route
               path="/year-1"
@@ -37,7 +39,11 @@ export default class AppRouter extends Component {
               setData={sets.yearTwo}
             />
 
-            <Route path="/base" component={Inventory} setData={sets.baseGame} />
+            <Route
+              path="/year-3"
+              component={Inventory}
+              setData={sets.yearThree}
+            />
 
             <Route
               path="/catalysts"

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -27,7 +27,8 @@ function isOverflowing(el) {
 
 const link = (name, to) => ({ name, to });
 const LINKS = [
-  link('Forsaken', '/'),
+  link('Year 3', '/'),
+  link('Year 2', '/year-2'),
   link('Year 1', '/year-1'),
   link('Strikes', '/strike-gear'),
   link('All Items', '/all-items'),
@@ -53,42 +54,42 @@ const SiteLinks = ({
   xurHasNewItems,
   showDataExplorerLink
 }) => (
-  <Fragment>
-    <div className={styles.dummyLink} />
+    <Fragment>
+      <div className={styles.dummyLink} />
 
-    {LINKS.map(({ name, to }) => (
-      <Link
-        key={to}
-        className={styles.link}
-        activeClassName={styles.active}
-        to={to}
-      >
-        {name}
-      </Link>
-    ))}
+      {LINKS.map(({ name, to }) => (
+        <Link
+          key={to}
+          className={styles.link}
+          activeClassName={styles.active}
+          to={to}
+        >
+          {name}
+        </Link>
+      ))}
 
-    {showDataExplorerLink && (
-      <a
-        className={styles.link}
-        href="https://data.destinysets.com"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        Data Explorer
+      {showDataExplorerLink && (
+        <a
+          className={styles.link}
+          href="https://data.destinysets.com"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Data Explorer
       </a>
-    )}
+      )}
 
-    {displayXur && (
-      <a
-        onClick={() => openXurModal(true)}
-        className={cx(styles.xurLink, xurHasNewItems && styles.xurLinkNewItems)}
-      >
-        <img className={styles.xurIcon} src={xur} alt="" />
-        Xûr
+      {displayXur && (
+        <a
+          onClick={() => openXurModal(true)}
+          className={cx(styles.xurLink, xurHasNewItems && styles.xurLinkNewItems)}
+        >
+          <img className={styles.xurIcon} src={xur} alt="" />
+          Xûr
       </a>
-    )}
-  </Fragment>
-);
+      )}
+    </Fragment>
+  );
 
 const SocialLinks = () => (
   <Fragment>

--- a/src/extraData/consoleExclusives.js
+++ b/src/extraData/consoleExclusives.js
@@ -1,24 +1,24 @@
-module.exports = {
-  ps4: [
-    3994031968, // Red Moon Phantom Mask
-    1601578801, // Red Moon Phantom Grips
-    3612275815, // Red Moon Phantom Vest
-    1432831619, // Red Moon Phantom Steps
-    32806262,   // Cloak of Five Full Moons
+// module.exports = {
+//   ps4: [
+//     3994031968, // Red Moon Phantom Mask
+//     1601578801, // Red Moon Phantom Grips
+//     3612275815, // Red Moon Phantom Vest
+//     1432831619, // Red Moon Phantom Steps
+//     32806262,   // Cloak of Five Full Moons
 
-    3839471140, // Mimetic Savior Helm
-    3403784957, // Mimetic Savior Gauntlets
-    3066154883, // Mimetic Savior Plate
-    1432969759, // Mimetic Savior Greaves
-    1964977914, // Mimetic Savior Bond
+//     3839471140, // Mimetic Savior Helm
+//     3403784957, // Mimetic Savior Gauntlets
+//     3066154883, // Mimetic Savior Plate
+//     1432969759, // Mimetic Savior Greaves
+//     1964977914, // Mimetic Savior Bond
 
-    2470746631, // Thorium Holt Hood
-    417345678,  // Thorium Holt Gloves
-    1330107298, // Thorium Holt Robes
-    2924984456, // Thorium Holt Boots
-    554000115,  // Thorium Holt Bond
+//     2470746631, // Thorium Holt Hood
+//     417345678,  // Thorium Holt Gloves
+//     1330107298, // Thorium Holt Robes
+//     2924984456, // Thorium Holt Boots
+//     554000115,  // Thorium Holt Bond
 
-    1852863732, // Wavesplitter
-    1673638926  // The Great Beyond
-  ]
-};
+//     1852863732, // Wavesplitter
+//     1673638926  // The Great Beyond
+//   ]
+// };

--- a/src/extraData/consoleExclusives.js
+++ b/src/extraData/consoleExclusives.js
@@ -1,24 +1,24 @@
-// module.exports = {
-//   ps4: [
-//     3994031968, // Red Moon Phantom Mask
-//     1601578801, // Red Moon Phantom Grips
-//     3612275815, // Red Moon Phantom Vest
-//     1432831619, // Red Moon Phantom Steps
-//     32806262,   // Cloak of Five Full Moons
+module.exports = {
+    //   ps4: [
+    //     3994031968, // Red Moon Phantom Mask
+    //     1601578801, // Red Moon Phantom Grips
+    //     3612275815, // Red Moon Phantom Vest
+    //     1432831619, // Red Moon Phantom Steps
+    //     32806262,   // Cloak of Five Full Moons
 
-//     3839471140, // Mimetic Savior Helm
-//     3403784957, // Mimetic Savior Gauntlets
-//     3066154883, // Mimetic Savior Plate
-//     1432969759, // Mimetic Savior Greaves
-//     1964977914, // Mimetic Savior Bond
+    //     3839471140, // Mimetic Savior Helm
+    //     3403784957, // Mimetic Savior Gauntlets
+    //     3066154883, // Mimetic Savior Plate
+    //     1432969759, // Mimetic Savior Greaves
+    //     1964977914, // Mimetic Savior Bond
 
-//     2470746631, // Thorium Holt Hood
-//     417345678,  // Thorium Holt Gloves
-//     1330107298, // Thorium Holt Robes
-//     2924984456, // Thorium Holt Boots
-//     554000115,  // Thorium Holt Bond
+    //     2470746631, // Thorium Holt Hood
+    //     417345678,  // Thorium Holt Gloves
+    //     1330107298, // Thorium Holt Robes
+    //     2924984456, // Thorium Holt Boots
+    //     554000115,  // Thorium Holt Bond
 
-//     1852863732, // Wavesplitter
-//     1673638926  // The Great Beyond
-//   ]
-// };
+    //     1852863732, // Wavesplitter
+    //     1673638926  // The Great Beyond
+    //   ]
+};

--- a/src/setData/baseGame.js
+++ b/src/setData/baseGame.js
@@ -730,7 +730,7 @@ export default ([
             items: [269552461, 922218300, 1415533220, 308026950, 2159363321]
           },
           {
-            name: 'Icarus Drifter - PS4 Exclusive',
+            name: 'Icarus Drifter',
             items: [155832748, 3646674533, 3066593211, 3569443559, 1847870034]
           },
           {
@@ -768,7 +768,7 @@ export default ([
             items: [3725654227, 1260134370, 2932121030, 3304280092, 3250112431]
           },
           {
-            name: 'Terra Concord - PS4 Exclusive',
+            name: 'Terra Concord',
             items: [690335398, 3999262583, 3291075521, 1512829977, 4073580572]
           },
           {
@@ -806,7 +806,7 @@ export default ([
             items: [993844472, 1457647945, 410671183, 1749589787, 2082184158]
           },
           {
-            name: 'Tesseract Trace - PS4 Exclusive',
+            name: 'Tesseract Trace',
             items: [2811180959, 3169402598, 4092393610, 2728535008, 434243995]
           },
           {

--- a/src/setData/dlc2.js
+++ b/src/setData/dlc2.js
@@ -412,7 +412,7 @@ export default ([
     name: 'Other',
     sets: [
       {
-        name: '"Insight" Armor - PS4 Exclusive',
+        name: '"Insight" Armor',
         id: 'WARMIND_INSIGHT',
         sections: [
           {

--- a/src/setData/index.js
+++ b/src/setData/index.js
@@ -3,6 +3,7 @@
 export default {
   yearOne: require('./yearOne').default,
   yearTwo: require('./yearTwo').default,
+  yearThree: require('./yearThree').default,
   dlc1: require('./dlc1').default,
   dlc2: require('./dlc2').default,
   baseGame: require('./baseGame').default,

--- a/src/setData/strikeGear.js
+++ b/src/setData/strikeGear.js
@@ -266,5 +266,24 @@ export default ([
         [1814407142, 1582507554]
       )
     ]
+  },
+  {
+    name: 'Shadowkeep',
+    sets: [
+      strike(
+        'The Festering Core',
+        'STRIKE_THE_FESTERING_CORE',
+        '/img/destiny_content/pgcr/strike_lake_of_shadows.jpg', // Double Check
+        [3745974521], // Double Check
+        [1184965378, 4179974574] // Double Check
+      ),
+      strike(
+        'The Scarlet Keep',
+        'STRIKE_THE_SCARLET_KEEP',
+        '/img/destiny_content/pgcr/strike_glee.jpg', // Double Check
+        [2154059444], // Double Check
+        [3844225097, 3597022727] // Double Check
+      )
+    ]
   }
 ]: SetPage);

--- a/src/setData/strikeGear.js
+++ b/src/setData/strikeGear.js
@@ -267,24 +267,7 @@ export default ([
       )
     ]
   },
-  // Placeholders Below
-  // {
-  //   name: 'Shadowkeep',
-  //   sets: [
-  //     strike(
-  //       'The Festering Core',
-  //       'STRIKE_THE_FESTERING_CORE',
-  //       '/img/destiny_content/pgcr/strike_lake_of_shadows.jpg', // Double Check
-  //       [3745974521], // Double Check
-  //       [1184965378, 4179974574] // Double Check
-  //     ),
-  //     strike(
-  //       'The Scarlet Keep',
-  //       'STRIKE_THE_SCARLET_KEEP',
-  //       '/img/destiny_content/pgcr/strike_glee.jpg', // Double Check
-  //       [2154059444], // Double Check
-  //       [3844225097, 3597022727] // Double Check
-  //     )
-  //   ]
-  // }
+
+  // 1655929400 - The Ordeal
+
 ]: SetPage);

--- a/src/setData/strikeGear.js
+++ b/src/setData/strikeGear.js
@@ -8,12 +8,12 @@ const strike = (name, id, image, exclusiveItems, emblems) => ({
   image,
   sections: [
     {
-      name: 'Nightfall exclusive',
+      name: 'Nightfall Exclusive',
       bigItems: true,
       items: exclusiveItems
     },
     {
-      name: 'Nightfall emblems',
+      name: 'Nightfall Emblems',
       items: emblems
     }
   ]
@@ -43,12 +43,12 @@ export default ([
         image: '/img/destiny_content/pgcr/strike_the_pyramdion.jpg',
         sections: [
           {
-            name: 'Nightfall exclusive',
+            name: 'Nightfall Exclusive',
             bigItems: true,
             items: [990416096] // Silicon Neuroma
           },
           {
-            name: 'Nightfall emblems',
+            name: 'Nightfall Emblems',
             items: [
               10493725, // The Pyramidion
               1078226395, // Operation Intrepid
@@ -64,12 +64,12 @@ export default ([
         image: '/img/destiny_content/pgcr/strike_exodus_crash.jpg',
         sections: [
           {
-            name: 'Nightfall exclusive',
+            name: 'Nightfall Exclusive',
             bigItems: true,
             items: [2757144093] // Impact Velocity
           },
           {
-            name: 'Nightfall emblems',
+            name: 'Nightfall Emblems',
             items: [
               2726018197, // Exodus Crash
               769740914, // Better Failsafe Than Sorry
@@ -85,12 +85,12 @@ export default ([
         image: '/img/destiny_content/pgcr/strike_the_arms_dealer.jpg',
         sections: [
           {
-            name: 'Nightfall exclusive',
+            name: 'Nightfall Exclusive',
             bigItems: true,
             items: [2757144092] // Tilt Fuse
           },
           {
-            name: 'Nightfall emblems',
+            name: 'Nightfall Emblems',
             items: [
               997563763, // The Arms Dealer
               2399682325, // Outlawed and Unsanctioned
@@ -106,12 +106,12 @@ export default ([
         image: '/img/destiny_content/pgcr/strike_savanthuns_song.jpg',
         sections: [
           {
-            name: 'Nightfall exclusive',
+            name: 'Nightfall Exclusive',
             bigItems: true,
             items: [1457979868] // Duty Bound
           },
           {
-            name: 'Nightfall emblems',
+            name: 'Nightfall Emblems',
             items: [
               148664963, // Savathûn's Song
               4040838277, // Search and Rescue
@@ -132,14 +132,14 @@ export default ([
         image: '/img/destiny_content/pgcr/campaign_tree_of_probabilities.jpg',
         sections: [
           {
-            name: 'Nightfall exclusive',
+            name: 'Nightfall Exclusive',
             bigItems: true,
             items: [
               4238497225 // D.F.A.
             ]
           },
           {
-            name: 'Nightfall emblems',
+            name: 'Nightfall Emblems',
             items: [
               2933984410, // Tree of Probabilities
               2178159623, // No More Lasers
@@ -155,14 +155,14 @@ export default ([
         image: '/img/destiny_content/pgcr/rituals_a_garden_world.jpg',
         sections: [
           {
-            name: 'Nightfall exclusive',
+            name: 'Nightfall Exclusive',
             bigItems: true,
             items: [
               1174053886 // Universal Wavefunction
             ]
           },
           {
-            name: 'Nightfall emblems',
+            name: 'Nightfall Emblems',
             items: [
               893502917, // A Garden World
               1505307650, // Blast from the Past
@@ -184,14 +184,14 @@ export default ([
         image: '/img/destiny_content/pgcr/strike_xol.jpg',
         sections: [
           {
-            name: 'Nightfall exclusive',
+            name: 'Nightfall Exclusive',
             bigItems: true,
             items: [
               1311389413 // Worm God Incarnation
             ]
           },
           {
-            name: 'Nightfall emblems',
+            name: 'Nightfall Emblems',
             items: [
               3427785728, // Will of the Thousands
               1456844009, // Feast of Worms
@@ -207,14 +207,14 @@ export default ([
         image: '/img/destiny_content/pgcr/strike_nokris.jpg',
         sections: [
           {
-            name: 'Nightfall exclusive',
+            name: 'Nightfall Exclusive',
             bigItems: true,
             items: [
               1929278169 // BrayTech Osprey
             ]
           },
           {
-            name: 'Nightfall emblems',
+            name: 'Nightfall Emblems',
             items: [
               2136479687, // Strange Terrain
               1901100185, // Maleficarum Interrupted

--- a/src/setData/strikeGear.js
+++ b/src/setData/strikeGear.js
@@ -267,23 +267,24 @@ export default ([
       )
     ]
   },
-  {
-    name: 'Shadowkeep',
-    sets: [
-      strike(
-        'The Festering Core',
-        'STRIKE_THE_FESTERING_CORE',
-        '/img/destiny_content/pgcr/strike_lake_of_shadows.jpg', // Double Check
-        [3745974521], // Double Check
-        [1184965378, 4179974574] // Double Check
-      ),
-      strike(
-        'The Scarlet Keep',
-        'STRIKE_THE_SCARLET_KEEP',
-        '/img/destiny_content/pgcr/strike_glee.jpg', // Double Check
-        [2154059444], // Double Check
-        [3844225097, 3597022727] // Double Check
-      )
-    ]
-  }
+  // Placeholders Below
+  // {
+  //   name: 'Shadowkeep',
+  //   sets: [
+  //     strike(
+  //       'The Festering Core',
+  //       'STRIKE_THE_FESTERING_CORE',
+  //       '/img/destiny_content/pgcr/strike_lake_of_shadows.jpg', // Double Check
+  //       [3745974521], // Double Check
+  //       [1184965378, 4179974574] // Double Check
+  //     ),
+  //     strike(
+  //       'The Scarlet Keep',
+  //       'STRIKE_THE_SCARLET_KEEP',
+  //       '/img/destiny_content/pgcr/strike_glee.jpg', // Double Check
+  //       [2154059444], // Double Check
+  //       [3844225097, 3597022727] // Double Check
+  //     )
+  //   ]
+  // }
 ]: SetPage);

--- a/src/setData/yearOne.js
+++ b/src/setData/yearOne.js
@@ -1332,12 +1332,12 @@ export default ([
             items: [269552461, 922218300, 1415533220, 308026950, 2159363321]
           },
           {
-            name: 'Icarus Drifter - PS4 Exclusive',
+            name: 'Icarus Drifter',
             season: 1,
             items: [155832748, 3646674533, 3066593211, 3569443559, 1847870034]
           },
           {
-            name: 'Insight - PS4 Exclusive',
+            name: 'Insight',
             season: 3,
             items: [
               1680657538, // Insight Rover Mask
@@ -1388,12 +1388,12 @@ export default ([
             items: [3725654227, 1260134370, 2932121030, 3304280092, 3250112431]
           },
           {
-            name: 'Terra Concord - PS4 Exclusive',
+            name: 'Terra Concord',
             season: 1,
             items: [690335398, 3999262583, 3291075521, 1512829977, 4073580572]
           },
           {
-            name: 'Insight - PS4 Exclusive',
+            name: 'Insight',
             season: 3,
             items: [
               1192751404, // Insight Unyielding Helm
@@ -1444,12 +1444,12 @@ export default ([
             items: [993844472, 1457647945, 410671183, 1749589787, 2082184158]
           },
           {
-            name: 'Tesseract Trace - PS4 Exclusive',
+            name: 'Tesseract Trace',
             season: 1,
             items: [2811180959, 3169402598, 4092393610, 2728535008, 434243995]
           },
           {
-            name: 'Insight - PS4 Exclusive',
+            name: 'Insight',
             season: 3,
             items: [
               2905154661, // Insight Vikti Hood
@@ -1763,23 +1763,23 @@ export default ([
             name: 'Ornaments',
             season: 1,
             items: [
-                3434280692, // Sub-Zero
-                2110420504, // Down to Business
-                2760478958, // Book of the Dead
-                1856805547, // Particle Accelerator
-                1630611952, // Red Dwarf
-                20859173, // Symbiosis
-                3925009772, // Black Plague
-                3520552272, // Summer Storm
-                1014060907, // Break the Dawn
-                3034617041, // Jade Countenance
-                4236694804, // Under Construction
-                2412488653, // Mind of Its Own
-                2583504679, // Tesla's Revenge
-                3628862572, // Comstock Lode
-                2673403667, // The Future is Chrome
-                1135501644, // Titanium Alloy
-                1748595581 // Beware the Red Legion
+              3434280692, // Sub-Zero
+              2110420504, // Down to Business
+              2760478958, // Book of the Dead
+              1856805547, // Particle Accelerator
+              1630611952, // Red Dwarf
+              20859173, // Symbiosis
+              3925009772, // Black Plague
+              3520552272, // Summer Storm
+              1014060907, // Break the Dawn
+              3034617041, // Jade Countenance
+              4236694804, // Under Construction
+              2412488653, // Mind of Its Own
+              2583504679, // Tesla's Revenge
+              3628862572, // Comstock Lode
+              2673403667, // The Future is Chrome
+              1135501644, // Titanium Alloy
+              1748595581 // Beware the Red Legion
             ]
           },
           {

--- a/src/setData/yearThree.js
+++ b/src/setData/yearThree.js
@@ -98,7 +98,9 @@ export default ([
             name: 'Extras',
             season: 8,
             items: [
-              3219975799 // Honorable Duelist Shell
+              3219975799, // Honorable Duelist Shell
+              1392223752, // Crucible Vermillion
+              1392223753 // Crucible Lazurite
             ]
           }
         ]

--- a/src/setData/yearThree.js
+++ b/src/setData/yearThree.js
@@ -144,7 +144,7 @@ export default ([
       {
         name: _(
           'DestinyActivityModeDefinition[332181804].displayProperties.name',
-          'Nightmare Hunts'
+          'Nightmare Hunt'
         ),
         id: 'year-three-nightmare-hunts',
         // description: _(

--- a/src/setData/yearThree.js
+++ b/src/setData/yearThree.js
@@ -15,34 +15,13 @@ export default ([
         id: 'year-three-strikes',
         description: 'Complete necessary pursuits from Commander Zavala.',
         sections: [
-          // {
-          //   name: 'Weapons',
-          //   season: 8, // Double Check
-          //   items: [
-
-          //   ]
-          // },
-          // {
-          //   name: 'Hunter Armor',
-          //   season: 8, // Double Check
-          //   items: [
-
-          //   ]
-          // },
-          // {
-          //   name: 'Titan Armor',
-          //   season: 8, // Double Check
-          //   items: [
-
-          //   ]
-          // },
-          // {
-          //   name: 'Warlock Armor',
-          //   season: 8, // Double Check
-          //   items: [
-
-          //   ]
-          // },
+          {
+            name: 'Weapons',
+            season: 8, // Double Check
+            items: [
+              847329160 // Edgewise
+            ]
+          },
           {
             name: 'Extras',
             season: 8, // Double Check
@@ -62,34 +41,13 @@ export default ([
         id: 'year-three-crucible',
         description: 'Complete necessary pursuits from Lord Shaxx.',
         sections: [
-          // {
-          //   name: 'Weapons',
-          //   season: 8, // Double Check
-          //   items: [
-
-          //   ]
-          // },
-          // {
-          //   name: 'Hunter Armor',
-          //   season: 8, // Double Check
-          //   items: [
-
-          //   ]
-          // },
-          // {
-          //   name: 'Titan Armor',
-          //   season: 8, // Double Check
-          //   items: [
-
-          //   ]
-          // },
-          // {
-          //   name: 'Warlock Armor',
-          //   season: 8, // Double Check
-          //   items: [
-
-          //   ]
-          // },
+          {
+            name: 'Weapons',
+            season: 8, // Double Check
+            items: [
+              3535742959 // Randy's Throwing Knife
+            ]
+          },
           {
             name: 'Extras',
             season: 8,
@@ -110,34 +68,13 @@ export default ([
         id: 'year-three-gambit',
         description: 'Complete necessary pursuits from the Drifter.',
         sections: [
-          // {
-          //   name: 'Weapons',
-          //   season: 8, // Double Check
-          //   items: [
-
-          //   ]
-          // },
-          // {
-          //   name: 'Hunter Armor',
-          //   season: 8, // Double Check
-          //   items: [
-
-          //   ]
-          // },
-          // {
-          //   name: 'Titan Armor',
-          //   season: 8, // Double Check
-          //   items: [
-
-          //   ]
-          // },
-          // {
-          //   name: 'Warlock Armor',
-          //   season: 8, // Double Check
-          //   items: [
-
-          //   ]
-          // },
+          {
+            name: 'Weapons',
+            season: 8, // Double Check
+            items: [
+              4227181568 // Exit Strategy
+            ]
+          },
           {
             name: 'Extras',
             season: 8,
@@ -160,13 +97,6 @@ export default ([
           'Complete Iron Banner matches and earn rank-up packages from Lord Saladin.'
         ),
         sections: [
-          // {
-          //   name: 'Weapons',
-          //   season: 8, // Double Check
-          //   items: [
-
-          //   ]
-          // },
           {
             name: 'Hunter Armor',
             season: 8,
@@ -207,6 +137,26 @@ export default ([
               677674547, // Flying Foundry
               3340102521, // Iron Mossbone
               3340102520 // Iron Oxide
+            ]
+          }
+        ]
+      },
+      {
+        name: _(
+          'DestinyActivityModeDefinition[332181804].displayProperties.name',
+          'Nightmare Hunts'
+        ),
+        id: 'year-three-nightmare-hunts',
+        // description: _(
+        //   'DestinyCollectibleDefinition[1098138990].sourceString', // Double Check
+        //   'Complete Iron Banner matches and earn rank-up packages from Lord Saladin.' // Double Check
+        // ),
+        sections: [
+          {
+            name: 'Extras',
+            season: "K",
+            items: [
+              298334057 // A Sibyl's Dreams
             ]
           }
         ]
@@ -573,10 +523,7 @@ export default ([
           'Eververse' // Double Check
         ),
         id: 'year-three-eververse',
-        description: _(
-          'DestinyCollectibleDefinition[764786884].sourceString', // Double Check
-          'Seasonal Bright Engrams.' // Double Check
-        ),
+        description: 'Items sold at Eververse for Bright Dust.',
         big: false, // Double Check
         sections: [
           {

--- a/src/setData/yearThree.js
+++ b/src/setData/yearThree.js
@@ -96,8 +96,8 @@ export default ([
             items: [
               3219975799, // Honorable Duelist Shell
               298334062, // Burnished Blade
-              1392223752, // Crucible Vermillion
-              1392223753 // Crucible Lazurite
+              1392223753, // Crucible Lazurite
+              1392223752 // Crucible Vermillion
             ]
           }
         ]
@@ -204,7 +204,9 @@ export default ([
             name: 'Extras',
             season: 8,
             items: [
-              677674547 // Flying Foundry
+              677674547, // Flying Foundry
+              3340102521, // Iron Mossbone
+              3340102520 // Iron Oxide
             ]
           }
         ]
@@ -565,100 +567,100 @@ export default ([
       //     }
       //   ]
       // },
-      // {
-      //   name: _(
-      //     'DestinyFactionDefinition[1393733616].displayProperties.name', // Double Check
-      //     'Eververse' // Double Check
-      //   ),
-      //   id: 'year-three-eververse',
-      //   description: _(
-      //     'DestinyCollectibleDefinition[764786884].sourceString', // Double Check
-      //     'Seasonal Bright Engrams.' // Double Check
-      //   ),
-      //   big: false, // Double Check
-      //   sections: [
-      //     {
-      //       name: 'Armor',
-      //       season: 8, // Double Check
-      //       itemGroups: [
-      //         [
-      //           // Hunter
+      {
+        name: _(
+          'DestinyFactionDefinition[1393733616].displayProperties.name', // Double Check
+          'Eververse' // Double Check
+        ),
+        id: 'year-three-eververse',
+        description: _(
+          'DestinyCollectibleDefinition[764786884].sourceString', // Double Check
+          'Seasonal Bright Engrams.' // Double Check
+        ),
+        big: false, // Double Check
+        sections: [
+          {
+            name: 'Armor',
+            season: 8, // Double Check
+            itemGroups: [
+              [
+                // Hunter
 
-      //         ],
-      //         [
-      //           // Titan
-      //         ],
-      //         [
-      //           // Warlock
-      //         ]
-      //       ]
-      //     },
-      //     {
-      //       name: 'Ornaments',
-      //       season: 8, // Double Check
-      //       itemGroups: [
-      //         [
-      //           // Exotic Weapon
-      //         ],
-      //         [
-      //           // Legendary Weapon
-      //         ],
-      //         [
-      //           // Exotic Armour
-      //         ]
-      //       ]
-      //     },
-      //     {
-      //       name: 'Emotes',
-      //       season: 8, // Double Check
-      //       items: [
+              ],
+              [
+                // Titan
+              ],
+              [
+                // Warlock
+              ]
+            ]
+          },
+          {
+            name: 'Ornaments',
+            season: 8, // Double Check
+            itemGroups: [
+              [
+                // Exotic Weapon
+              ],
+              [
+                // Legendary Weapon
+              ],
+              [
+                // Exotic Armour
+              ]
+            ]
+          },
+          {
+            name: 'Emotes',
+            season: 8, // Double Check
+            items: [
+              991204036 // Make it Stop
+            ]
+          },
+          {
+            name: 'Ghosts',
+            season: 8, // Double Check
+            items: [
 
-      //       ]
-      //     },
-      //     {
-      //       name: 'Ghosts',
-      //       season: 8, // Double Check
-      //       items: [
+            ]
+          },
+          {
+            name: 'Ghost Projections',
+            season: 8, // Double Check
+            items: [
 
-      //       ]
-      //     },
-      //     {
-      //       name: 'Ghost Projections',
-      //       season: 8, // Double Check
-      //       items: [
+            ]
+          },
+          {
+            name: 'Sparrows',
+            season: 8, // Double Check
+            items: [
 
-      //       ]
-      //     },
-      //     {
-      //       name: 'Sparrows',
-      //       season: 8, // Double Check
-      //       items: [
+            ]
+          },
+          {
+            name: 'Ships',
+            season: 8, // Double Check
+            items: [
 
-      //       ]
-      //     },
-      //     {
-      //       name: 'Ships',
-      //       season: 8, // Double Check
-      //       items: [
-
-      //       ]
-      //     },
-      //     {
-      //       name: 'Shaders',
-      //       season: 8, // Double Check
-      //       items: [
-
-      //       ]
-      //     },
-      //     {
-      //       name: 'Transmat Effects',
-      //       season: 8, // Double Check
-      //       items: [
-
-      //       ]
-      //     }
-      //   ]
-      // }
+            ]
+          },
+          {
+            name: 'Shaders',
+            season: 8, // Double Check
+            items: [
+              3818755494 // Bruised Blush
+            ]
+          },
+          {
+            name: 'Transmat Effects',
+            season: 8, // Double Check
+            items: [
+              3951356827 // Blind Clutch
+            ]
+          }
+        ]
+      }
     ]
   }
 ]: SetPage);

--- a/src/setData/yearThree.js
+++ b/src/setData/yearThree.js
@@ -57,109 +57,169 @@ export default ([
       },
       {
         name: _(
-          'DestinyActivityModeDefinition[1826469369].displayProperties.name', // Double Check
-          'Iron Banner' // Double Check
+          'DestinyActivityModeDefinition[1164760504].displayProperties.name', // Double Check
+          'Crucible' // Double Check
+        ),
+        id: 'YEAR_TWO_CRUCIBLE',
+        description: _(
+          'DestinyCollectibleDefinition[1279318105].sourceString', // Double Check
+          'Complete Crucible matches and earn rank-up packages from Lord Shaxx.' // Double Check
+        ),
+        sections: [
+          {
+            name: 'Weapons',
+            season: 8,
+            items: [
+
+            ]
+          },
+          {
+            name: 'Hunter Armor',
+            season: 8,
+            items: [
+
+            ]
+          },
+          {
+            name: 'Titan Armor',
+            season: 8,
+            items: [
+
+            ]
+          },
+          {
+            name: 'Warlock Armor',
+            season: 8,
+            items: [
+
+            ]
+          },
+          {
+            name: 'Extras',
+            season: 8,
+            items: [
+              3219975799 // Honorable Duelist Shell
+            ]
+          }
+        ]
+      },
+      {
+        name: _(
+          'DestinyActivityModeDefinition[1826469369].displayProperties.name',
+          'Iron Banner'
         ),
         id: 'year-iron-banner',
         description: _(
-          'DestinyCollectibleDefinition[3008980338].sourceString', // Double Check
-          'Complete Iron Banner matches and earn rank-up packages from Lord Saladin.' // Double Check
+          'DestinyCollectibleDefinition[3864000240].sourceString',
+          'Complete Iron Banner matches and earn rank-up packages from Lord Saladin.'
         ),
         sections: [
           {
             name: 'Weapons',
             season: 8, // Double Check
             items: [
-              2154059444
+
             ]
           },
           {
             name: 'Hunter Armor',
             season: 8, // Double Check
             items: [
-
+              1098138990, // Iron Will Mask
+              2547799775, // Iron Will Sleeves
+              1058936857, // Iron Will Vest
+              1469050017, // Iron Will Boots
+              2414679508 // Iron Will Cloak
             ]
           },
           {
             name: 'Titan Armor',
             season: 8, // Double Check
             items: [
-
+              1895324274, // Iron Will Helm
+              2320100699, // Iron Will Gauntlets
+              2536633781, // Iron Will Plate
+              770140877, // Iron Will Greaves
+              1234228360 // Iron Will Mark
             ]
           },
           {
             name: 'Warlock Armor',
             season: 8, // Double Check
             items: [
-
+              2205315921, // Iron Will Hood
+              863444264, // Iron Will Gloves
+              4128151712, // Iron Will Vestments
+              1498852482, // Iron Will Steps
+              3055410141 // Iron Will Bond
             ]
           },
           {
             name: 'Extras',
             season: 8, // Double Check
             items: [
-
+              677674547 // Flying Foundry
             ]
           }
         ]
       },
-      {
-        name: _(
-          'DestinyActivityModeDefinition[2394616003].displayProperties.name', // Double Check
-          'Vex Offensive' // Double Check
-        ),
-        id: 'year-vex-offensive',
-        description: _(
-          'DestinyCollectibleDefinition[2589931339].sourceString', // Double Check
-          'Complete strikes and earn rank-up packages from Commander Zavala.' // Double Check
-        ),
-        sections: [
-          {
-            name: 'Weapons',
-            season: 8, // Double Check
-            items: [
-              2154059444
-            ]
-          },
-          {
-            name: 'Hunter Armor',
-            season: 8, // Double Check
-            items: [
+      // {
+      //   name: _(
+      //     'DestinyActivityModeDefinition[2394616003].displayProperties.name', // Double Check
+      //     'Vex Offensive' // Double Check
+      //   ),
+      //   id: 'year-vex-offensive',
+      //   description: _(
+      //     'DestinyCollectibleDefinition[2589931339].sourceString', // Double Check
+      //     'Complete strikes and earn rank-up packages from Commander Zavala.' // Double Check
+      //   ),
+      //   sections: [
+      //     {
+      //       name: 'Weapons',
+      //       season: 8, // Double Check
+      //       items: [
+      //         2154059444
+      //       ]
+      //     },
+      //     {
+      //       name: 'Hunter Armor',
+      //       season: 8, // Double Check
+      //       items: [
 
-            ]
-          },
-          {
-            name: 'Titan Armor',
-            season: 8, // Double Check
-            items: [
+      //       ]
+      //     },
+      //     {
+      //       name: 'Titan Armor',
+      //       season: 8, // Double Check
+      //       items: [
 
-            ]
-          },
-          {
-            name: 'Warlock Armor',
-            season: 8, // Double Check
-            items: [
+      //       ]
+      //     },
+      //     {
+      //       name: 'Warlock Armor',
+      //       season: 8, // Double Check
+      //       items: [
 
-            ]
-          },
-          {
-            name: 'Extras',
-            season: 8, // Double Check
-            items: [
+      //       ]
+      //     },
+      //     {
+      //       name: 'Extras',
+      //       season: 8, // Double Check
+      //       items: [
 
-            ]
-          }
-        ]
-      },
+      //       ]
+      //     }
+      //   ]
+      // },
       {
         name: _(
           // 'DestinyActivityModeDefinition[2394616003].displayProperties.name', // Double Check
-          'Garden of Salvation' // Double Check
+          'Garden of Salvation'
         ),
         id: 'year-three-garden-of-salvation',
         description: _(
-          'DestinyCollectibleDefinition[2948134329].sourceString', // Double Check
-          '"Garden of Salvation" raid' // Double Check
+          'DestinyCollectibleDefinition[2948134329].sourceString',
+          '"Garden of Salvation" raid'
         ),
         sections: [
           {
@@ -226,212 +286,239 @@ export default ([
     sets: [
       {
         name: _(
-          'DestinyPlaceDefinition[975684424].displayProperties.name', // Double Check
-          'The Moon' // Double Check
+          'DestinyPlaceDefinition[3325508439].displayProperties.name',
+          'The Moon'
         ),
         id: 'year-three-moon',
         description: _(
-          'DestinyCollectibleDefinition[1350431641].sourceString', // Double Check
-          'Complete activities and earn rank-up packages on the Moon.' // Double Check
+          'DestinyCollectibleDefinition[1310958655].sourceString',
+          'Found by exploring the Moon.'
         ),
         sections: [
           {
             name: 'Weapons',
-            season: "K", // Double Check
+            season: "K",
             items: [
-              2154059444
+              2723909519, // Arc Logic
+              208088207, // Premonition
+              3924212056, // Loud Lullaby
+              4277547616, // Every Waking Moment
+              1016668089, // One Small Step
+              2931957300, // Dream Breaker
+              1645386487, // Tranquility
+              3870811754, // Night Terror
+              3690523502, // Love and Death
+              3325778512 // A Fine Memorial
             ]
           },
           {
             name: 'Hunter Armor',
-            season: "K", // Double Check
+            season: "K",
             items: [
-
+              659922705, // Dreambane Cowl
+              3571441640, // Dreambane Grips
+              883769696, // Dreambane Vest
+              377813570, // Dreambane Strides
+              193805725 // Dreambane Cloak
             ]
           },
           {
             name: 'Titan Armor',
-            season: "K", // Double Check
+            season: "K",
             items: [
-
+              272413517, // Dreambane Helm
+              925079356, // Dreambane Gauntlets
+              2568538788, // Dreambane Plate
+              310888006, // Dreambane Greaves
+              3312368889 // Dreambane Mark
             ]
           },
           {
             name: 'Warlock Armor',
-            season: "K", // Double Check
+            season: "K",
             items: [
-
+              1528483180, // Dreambane Hood
+              682780965, // Dreambane Gloves
+              3692187003, // Dreambane Robes
+              1030110631, // Dreambane Boots
+              2048903186 // Dreambane Bond
             ]
           },
           {
             name: 'Extras',
-            season: "K", // Double Check
+            season: "K",
             items: [
-
+              1272828316, // Moonshot Shell
+              3382260610, // Moonrider One
+              672488948, // The Third Tide
+              1714370698, // Orbital Cartographer
+              298334056, // Lunar Memoriam
+              2056256564, // Lunar Halcyon Gilt
+              2056256565 // Lunar Gloom
             ]
           }
         ]
       }
     ]
   },
-  {
-    name: 'Holiday & Special Events',
-    sets: [
-      {
-        name: 'Festival of the Lost',
-        id: 'year-three-festival-of-the-lost',
-        description: 'Earned during the seasonal Festival of the Lost event.', // Double Check
-        sections: [
-          {
-            name: 'Weapons',
-            season: 8, // Double Check
-            items: [
-              2154059444
-            ]
-          },
-          {
-            name: 'Hunter Armor',
-            season: 8, // Double Check
-            items: [
+  // {
+  //   name: 'Holiday & Special Events',
+  //   sets: [
+  //     {
+  //       name: 'Festival of the Lost',
+  //       id: 'year-three-festival-of-the-lost',
+  //       description: 'Earned during the seasonal Festival of the Lost event.', // Double Check
+  //       sections: [
+  //         {
+  //           name: 'Weapons',
+  //           season: 8, // Double Check
+  //           items: [
+  //             2154059444
+  //           ]
+  //         },
+  //         {
+  //           name: 'Hunter Armor',
+  //           season: 8, // Double Check
+  //           items: [
 
-            ]
-          },
-          {
-            name: 'Titan Armor',
-            season: 8, // Double Check
-            items: [
+  //           ]
+  //         },
+  //         {
+  //           name: 'Titan Armor',
+  //           season: 8, // Double Check
+  //           items: [
 
-            ]
-          },
-          {
-            name: 'Warlock Armor',
-            season: 8, // Double Check
-            items: [
+  //           ]
+  //         },
+  //         {
+  //           name: 'Warlock Armor',
+  //           season: 8, // Double Check
+  //           items: [
 
-            ]
-          },
-          {
-            name: 'Masks',
-            season: 8, // Double Check
-            items: [
+  //           ]
+  //         },
+  //         {
+  //           name: 'Masks',
+  //           season: 8, // Double Check
+  //           items: [
 
-            ]
-          },
-          {
-            name: 'Emotes',
-            season: 8, // Double Check
-            items: [
+  //           ]
+  //         },
+  //         {
+  //           name: 'Emotes',
+  //           season: 8, // Double Check
+  //           items: [
 
-            ]
-          },
-          {
-            name: 'Ghosts',
-            season: 8, // Double Check
-            items: [
+  //           ]
+  //         },
+  //         {
+  //           name: 'Ghosts',
+  //           season: 8, // Double Check
+  //           items: [
 
-            ]
-          },
-          {
-            name: 'Ghost Projections',
-            season: 8, // Double Check
-            items: [
+  //           ]
+  //         },
+  //         {
+  //           name: 'Ghost Projections',
+  //           season: 8, // Double Check
+  //           items: [
 
-            ]
-          },
-          {
-            name: 'Sparrows',
-            season: 8, // Double Check
-            items: [
+  //           ]
+  //         },
+  //         {
+  //           name: 'Sparrows',
+  //           season: 8, // Double Check
+  //           items: [
 
-            ]
-          },
-          {
-            name: 'Ships',
-            season: 8, // Double Check
-            items: [
+  //           ]
+  //         },
+  //         {
+  //           name: 'Ships',
+  //           season: 8, // Double Check
+  //           items: [
 
-            ]
-          },
-          {
-            name: 'Extras',
-            season: 8, // Double Check
-            items: [
+  //           ]
+  //         },
+  //         {
+  //           name: 'Extras',
+  //           season: 8, // Double Check
+  //           items: [
 
-            ]
-          }
-        ]
-      },
-    ]
-  },
+  //           ]
+  //         }
+  //       ]
+  //     },
+  //   ]
+  // },
   {
     name: 'Other',
     sets: [
-      {
-        name: _(
-          'DestinyVendorDefinition[3163810067].displayProperties.name',
-          'Legendary Engram'
-        ),
-        description: _(
-          'DestinyCollectibleDefinition[256984755].sourceString',
-          'Open Legendary engrams and earn faction rank-up packages.'
-        ),
-        id: 'year-three-legendary-engram',
-        big: false, // Double Check
-        sections: [
-          {
-            name: 'Weapons',
-            season: 4,
-            items: [
-              2154059444
-            ]
-          },
-          {
-            name: 'Hunter Armor',
-            season: 4,
-            itemGroups: [
-              [
+      // {
+      //   name: _(
+      //     'DestinyVendorDefinition[3163810067].displayProperties.name',
+      //     'Legendary Engram'
+      //   ),
+      //   description: _(
+      //     'DestinyCollectibleDefinition[256984755].sourceString',
+      //     'Open Legendary engrams and earn faction rank-up packages.'
+      //   ),
+      //   id: 'year-three-legendary-engram',
+      //   big: false, // Double Check
+      //   sections: [
+      //     {
+      //       name: 'Weapons',
+      //       season: 4,
+      //       items: [
 
-              ],
-              [
+      //       ]
+      //     },
+      //     {
+      //       name: 'Hunter Armor',
+      //       season: 4,
+      //       itemGroups: [
+      //         [
 
-              ],
-              [
+      //         ],
+      //         [
 
-              ]
-            ]
-          },
-          {
-            name: 'Titan Armor',
-            season: 4,
-            itemGroups: [
-              [
+      //         ],
+      //         [
 
-              ],
-              [
+      //         ]
+      //       ]
+      //     },
+      //     {
+      //       name: 'Titan Armor',
+      //       season: 4,
+      //       itemGroups: [
+      //         [
 
-              ],
-              [
+      //         ],
+      //         [
 
-              ]
-            ]
-          },
-          {
-            name: 'Warlock Armor',
-            season: 4,
-            itemGroups: [
-              [
+      //         ],
+      //         [
 
-              ],
-              [
+      //         ]
+      //       ]
+      //     },
+      //     {
+      //       name: 'Warlock Armor',
+      //       season: 4,
+      //       itemGroups: [
+      //         [
 
-              ],
-              [
+      //         ],
+      //         [
 
-              ]
-            ]
-          }
-        ]
-      },
+      //         ],
+      //         [
+
+      //         ]
+      //       ]
+      //     }
+      //   ]
+      // },
       {
         name: _(
           'DestinyFactionDefinition[1393733616].displayProperties.name', // Double Check

--- a/src/setData/yearThree.js
+++ b/src/setData/yearThree.js
@@ -153,48 +153,68 @@ export default ([
       },
       {
         name: _(
-          'DestinyActivityModeDefinition[2394616003].displayProperties.name', // Double Check
+          // 'DestinyActivityModeDefinition[2394616003].displayProperties.name', // Double Check
           'Garden of Salvation' // Double Check
         ),
-        id: 'year-garden-of-salvation',
+        id: 'year-three-garden-of-salvation',
         description: _(
-          'DestinyCollectibleDefinition[2589931339].sourceString', // Double Check
-          'Complete strikes and earn rank-up packages from Commander Zavala.' // Double Check
+          'DestinyCollectibleDefinition[2948134329].sourceString', // Double Check
+          '"Garden of Salvation" raid' // Double Check
         ),
         sections: [
           {
             name: 'Weapons',
             season: "K", // Double Check
             items: [
-              2154059444
+              3385326721, // Reckless Oracle
+              2408405461, // Sacred Provenance
+              48643186, // Ancient Gospel
+              4095896073, // Accrued Redemption
+              4020742303, // Prophet of Doom
+              2209003210, // Zealot's Reward
+              3454326177 // Omniscient Eye
             ]
           },
           {
             name: 'Hunter Armor',
             season: "K", // Double Check
             items: [
-
+              1399922251, // Cowl of Righteousness
+              1653741426, // Grips of Exaltation
+              4177973942, // Vest of Transcendence
+              2054979724, // Strides of Ascendancy 
+              3549177695 // Cloak of Temptation
             ]
           },
           {
             name: 'Titan Armor',
             season: "K", // Double Check
             items: [
-
+              519078295, // Helm of Righteousness
+              3887559710, // Gauntlets of Exaltation
+              3939809874, // Plate of Transcendence
+              11974904, // Greaves of Ascendancy
+              281660259 // Temptation's Mark
             ]
           },
           {
             name: 'Warlock Armor',
             season: "K", // Double Check
             items: [
-
+              3001934726, // Mask of Righteousness
+              2015894615, // Gloves of Exaltation
+              2320830625, // Robes of Transcendence
+              3824429433, // Boots of Ascendancy
+              3103335676 // Temptation's Bond
             ]
           },
           {
             name: 'Extras',
             season: "K", // Double Check
             items: [
-
+              298334059, // Inherent Truth
+              3996862462, // Ancient Believer 
+              3996862463 // Ancient Defender
             ]
           }
         ]

--- a/src/setData/yearThree.js
+++ b/src/setData/yearThree.js
@@ -7,100 +7,144 @@ export default ([
   {
     name: 'Activities',
     sets: [
-      // {
-      //   name: _(
-      //     'DestinyActivityModeDefinition[2394616003].displayProperties.name', // Double Check
-      //     'Strikes' // Double Check
-      //   ),
-      //   id: 'year-three-strikes',
-      //   description: _(
-      //     'DestinyCollectibleDefinition[2589931339].sourceString', // Double Check
-      //     'Complete strikes and earn rank-up packages from Commander Zavala.' // Double Check
-      //   ),
-      //   sections: [
-      //     {
-      //       name: 'Weapons',
-      //       season: "K", // Double Check
-      //       items: [
-
-      //       ]
-      //     },
-      //     {
-      //       name: 'Hunter Armor',
-      //       season: "K", // Double Check
-      //       items: [
-
-      //       ]
-      //     },
-      //     {
-      //       name: 'Titan Armor',
-      //       season: "K", // Double Check
-      //       items: [
-
-      //       ]
-      //     },
-      //     {
-      //       name: 'Warlock Armor',
-      //       season: "K", // Double Check
-      //       items: [
-
-      //       ]
-      //     },
-      //     {
-      //       name: 'Extras',
-      //       season: "K", // Double Check
-      //       items: [
-
-      //       ]
-      //     }
-      //   ]
-      // },
       {
         name: _(
-          'DestinyActivityModeDefinition[1164760504].displayProperties.name', // Double Check
-          'Crucible' // Double Check
+          'DestinyActivityModeDefinition[2394616003].displayProperties.name',
+          'Strikes'
         ),
-        id: 'YEAR_TWO_CRUCIBLE',
-        description: _(
-          'DestinyCollectibleDefinition[1279318105].sourceString', // Double Check
-          'Complete Crucible matches and earn rank-up packages from Lord Shaxx.' // Double Check
-        ),
+        id: 'year-three-strikes',
+        description: 'Complete necessary pursuits from Commander Zavala.',
         sections: [
-          {
-            name: 'Weapons',
-            season: 8,
-            items: [
+          // {
+          //   name: 'Weapons',
+          //   season: 8, // Double Check
+          //   items: [
 
-            ]
-          },
-          {
-            name: 'Hunter Armor',
-            season: 8,
-            items: [
+          //   ]
+          // },
+          // {
+          //   name: 'Hunter Armor',
+          //   season: 8, // Double Check
+          //   items: [
 
-            ]
-          },
-          {
-            name: 'Titan Armor',
-            season: 8,
-            items: [
+          //   ]
+          // },
+          // {
+          //   name: 'Titan Armor',
+          //   season: 8, // Double Check
+          //   items: [
 
-            ]
-          },
-          {
-            name: 'Warlock Armor',
-            season: 8,
-            items: [
+          //   ]
+          // },
+          // {
+          //   name: 'Warlock Armor',
+          //   season: 8, // Double Check
+          //   items: [
 
+          //   ]
+          // },
+          {
+            name: 'Extras',
+            season: 8, // Double Check
+            items: [
+              298334049, // Timeless Vigil
+              2058800852, // Vanguard Stratosphere
+              2058800853 // Vanguard Angelos
             ]
-          },
+          }
+        ]
+      },
+      {
+        name: _(
+          'DestinyActivityModeDefinition[1164760504].displayProperties.name',
+          'Crucible'
+        ),
+        id: 'year-three-crucible',
+        description: 'Complete necessary pursuits from Lord Shaxx.',
+        sections: [
+          // {
+          //   name: 'Weapons',
+          //   season: 8, // Double Check
+          //   items: [
+
+          //   ]
+          // },
+          // {
+          //   name: 'Hunter Armor',
+          //   season: 8, // Double Check
+          //   items: [
+
+          //   ]
+          // },
+          // {
+          //   name: 'Titan Armor',
+          //   season: 8, // Double Check
+          //   items: [
+
+          //   ]
+          // },
+          // {
+          //   name: 'Warlock Armor',
+          //   season: 8, // Double Check
+          //   items: [
+
+          //   ]
+          // },
           {
             name: 'Extras',
             season: 8,
             items: [
               3219975799, // Honorable Duelist Shell
+              298334062, // Burnished Blade
               1392223752, // Crucible Vermillion
               1392223753 // Crucible Lazurite
+            ]
+          }
+        ]
+      },
+      {
+        name: _(
+          'DestinyActivityModeDefinition[1848252830].displayProperties.name',
+          'Gambit'
+        ),
+        id: 'year-three-gambit',
+        description: 'Complete necessary pursuits from the Drifter.',
+        sections: [
+          // {
+          //   name: 'Weapons',
+          //   season: 8, // Double Check
+          //   items: [
+
+          //   ]
+          // },
+          // {
+          //   name: 'Hunter Armor',
+          //   season: 8, // Double Check
+          //   items: [
+
+          //   ]
+          // },
+          // {
+          //   name: 'Titan Armor',
+          //   season: 8, // Double Check
+          //   items: [
+
+          //   ]
+          // },
+          // {
+          //   name: 'Warlock Armor',
+          //   season: 8, // Double Check
+          //   items: [
+
+          //   ]
+          // },
+          {
+            name: 'Extras',
+            season: 8,
+            items: [
+              1714370697, // Living Vestige
+              1359616732, // Gambit Emerald
+              1359616733 // Gambit Celadon
             ]
           }
         ]
@@ -110,22 +154,22 @@ export default ([
           'DestinyActivityModeDefinition[1826469369].displayProperties.name',
           'Iron Banner'
         ),
-        id: 'year-iron-banner',
+        id: 'year-three-iron-banner',
         description: _(
-          'DestinyCollectibleDefinition[3864000240].sourceString',
+          'DestinyCollectibleDefinition[1098138990].sourceString',
           'Complete Iron Banner matches and earn rank-up packages from Lord Saladin.'
         ),
         sections: [
-          {
-            name: 'Weapons',
-            season: 8, // Double Check
-            items: [
+          // {
+          //   name: 'Weapons',
+          //   season: 8, // Double Check
+          //   items: [
 
-            ]
-          },
+          //   ]
+          // },
           {
             name: 'Hunter Armor',
-            season: 8, // Double Check
+            season: 8,
             items: [
               1098138990, // Iron Will Mask
               2547799775, // Iron Will Sleeves
@@ -136,7 +180,7 @@ export default ([
           },
           {
             name: 'Titan Armor',
-            season: 8, // Double Check
+            season: 8,
             items: [
               1895324274, // Iron Will Helm
               2320100699, // Iron Will Gauntlets
@@ -147,7 +191,7 @@ export default ([
           },
           {
             name: 'Warlock Armor',
-            season: 8, // Double Check
+            season: 8,
             items: [
               2205315921, // Iron Will Hood
               863444264, // Iron Will Gloves
@@ -158,7 +202,7 @@ export default ([
           },
           {
             name: 'Extras',
-            season: 8, // Double Check
+            season: 8,
             items: [
               677674547 // Flying Foundry
             ]
@@ -228,55 +272,55 @@ export default ([
             name: 'Weapons',
             season: "K", // Double Check
             items: [
-              3385326721, // Reckless Oracle
-              2408405461, // Sacred Provenance
-              48643186, // Ancient Gospel
-              4095896073, // Accrued Redemption
-              4020742303, // Prophet of Doom
-              2209003210, // Zealot's Reward
-              3454326177 // Omniscient Eye
+              // 3385326721, // Reckless Oracle
+              // 2408405461, // Sacred Provenance
+              // 48643186, // Ancient Gospel
+              // 4095896073, // Accrued Redemption
+              // 4020742303, // Prophet of Doom
+              // 2209003210, // Zealot's Reward
+              // 3454326177 // Omniscient Eye
             ]
           },
           {
             name: 'Hunter Armor',
             season: "K", // Double Check
             items: [
-              1399922251, // Cowl of Righteousness
-              1653741426, // Grips of Exaltation
-              4177973942, // Vest of Transcendence
-              2054979724, // Strides of Ascendancy 
-              3549177695 // Cloak of Temptation
+              // 1399922251, // Cowl of Righteousness
+              // 1653741426, // Grips of Exaltation
+              // 4177973942, // Vest of Transcendence
+              // 2054979724, // Strides of Ascendancy 
+              // 3549177695 // Cloak of Temptation
             ]
           },
           {
             name: 'Titan Armor',
             season: "K", // Double Check
             items: [
-              519078295, // Helm of Righteousness
-              3887559710, // Gauntlets of Exaltation
-              3939809874, // Plate of Transcendence
-              11974904, // Greaves of Ascendancy
-              281660259 // Temptation's Mark
+              // 519078295, // Helm of Righteousness
+              // 3887559710, // Gauntlets of Exaltation
+              // 3939809874, // Plate of Transcendence
+              // 11974904, // Greaves of Ascendancy
+              // 281660259 // Temptation's Mark
             ]
           },
           {
             name: 'Warlock Armor',
             season: "K", // Double Check
             items: [
-              3001934726, // Mask of Righteousness
-              2015894615, // Gloves of Exaltation
-              2320830625, // Robes of Transcendence
-              3824429433, // Boots of Ascendancy
-              3103335676 // Temptation's Bond
+              // 3001934726, // Mask of Righteousness
+              // 2015894615, // Gloves of Exaltation
+              // 2320830625, // Robes of Transcendence
+              // 3824429433, // Boots of Ascendancy
+              // 3103335676 // Temptation's Bond
             ]
           },
           {
             name: 'Extras',
             season: "K", // Double Check
             items: [
-              298334059, // Inherent Truth
-              3996862462, // Ancient Believer 
-              3996862463 // Ancient Defender
+              // 298334059, // Inherent Truth
+              // 3996862462, // Ancient Believer 
+              // 3996862463 // Ancient Defender
             ]
           }
         ]

--- a/src/setData/yearThree.js
+++ b/src/setData/yearThree.js
@@ -20,62 +20,9 @@ export default ([
         sections: [
           {
             name: 'Weapons',
-            season: "4", // Double Check
-            items: [
-
-            ]
-          },
-          {
-            name: 'Hunter Armor',
-            season: 4, // Double Check
-            items: [
-
-            ]
-          },
-          {
-            name: 'Titan Armor',
-            season: 4, // Double Check
-            items: [
-
-            ]
-          },
-          {
-            name: 'Warlock Armor',
-            season: 4, // Double Check
-            items: [
-
-            ]
-          },
-          {
-            name: 'Extras',
-            season: 4, // Double Check
-            items: [
-
-            ]
-          }
-        ]
-      }
-    ]
-  },
-  {
-    name: 'Destinations',
-    sets: [
-      {
-        name: _(
-          'DestinyPlaceDefinition[975684424].displayProperties.name', // Double Check
-          'The Moon' // Double Check
-        ),
-        id: 'year-three-moon',
-        description: _(
-          'DestinyCollectibleDefinition[1350431641].sourceString', // Double Check
-          'Complete activities and earn rank-up packages on the Moon.' // Double Check
-        ),
-        sections: [
-          {
-            name: 'Weapons',
             season: "K", // Double Check
             items: [
-
+              2154059444
             ]
           },
           {
@@ -108,6 +55,457 @@ export default ([
           }
         ]
       },
+      {
+        name: _(
+          'DestinyActivityModeDefinition[1826469369].displayProperties.name', // Double Check
+          'Iron Banner' // Double Check
+        ),
+        id: 'year-iron-banner',
+        description: _(
+          'DestinyCollectibleDefinition[3008980338].sourceString', // Double Check
+          'Complete Iron Banner matches and earn rank-up packages from Lord Saladin.' // Double Check
+        ),
+        sections: [
+          {
+            name: 'Weapons',
+            season: 8, // Double Check
+            items: [
+              2154059444
+            ]
+          },
+          {
+            name: 'Hunter Armor',
+            season: 8, // Double Check
+            items: [
+
+            ]
+          },
+          {
+            name: 'Titan Armor',
+            season: 8, // Double Check
+            items: [
+
+            ]
+          },
+          {
+            name: 'Warlock Armor',
+            season: 8, // Double Check
+            items: [
+
+            ]
+          },
+          {
+            name: 'Extras',
+            season: 8, // Double Check
+            items: [
+
+            ]
+          }
+        ]
+      },
+      {
+        name: _(
+          'DestinyActivityModeDefinition[2394616003].displayProperties.name', // Double Check
+          'Vex Offensive' // Double Check
+        ),
+        id: 'year-vex-offensive',
+        description: _(
+          'DestinyCollectibleDefinition[2589931339].sourceString', // Double Check
+          'Complete strikes and earn rank-up packages from Commander Zavala.' // Double Check
+        ),
+        sections: [
+          {
+            name: 'Weapons',
+            season: 8, // Double Check
+            items: [
+              2154059444
+            ]
+          },
+          {
+            name: 'Hunter Armor',
+            season: 8, // Double Check
+            items: [
+
+            ]
+          },
+          {
+            name: 'Titan Armor',
+            season: 8, // Double Check
+            items: [
+
+            ]
+          },
+          {
+            name: 'Warlock Armor',
+            season: 8, // Double Check
+            items: [
+
+            ]
+          },
+          {
+            name: 'Extras',
+            season: 8, // Double Check
+            items: [
+
+            ]
+          }
+        ]
+      },
+      {
+        name: _(
+          'DestinyActivityModeDefinition[2394616003].displayProperties.name', // Double Check
+          'Garden of Salvation' // Double Check
+        ),
+        id: 'year-garden-of-salvation',
+        description: _(
+          'DestinyCollectibleDefinition[2589931339].sourceString', // Double Check
+          'Complete strikes and earn rank-up packages from Commander Zavala.' // Double Check
+        ),
+        sections: [
+          {
+            name: 'Weapons',
+            season: "K", // Double Check
+            items: [
+              2154059444
+            ]
+          },
+          {
+            name: 'Hunter Armor',
+            season: "K", // Double Check
+            items: [
+
+            ]
+          },
+          {
+            name: 'Titan Armor',
+            season: "K", // Double Check
+            items: [
+
+            ]
+          },
+          {
+            name: 'Warlock Armor',
+            season: "K", // Double Check
+            items: [
+
+            ]
+          },
+          {
+            name: 'Extras',
+            season: "K", // Double Check
+            items: [
+
+            ]
+          }
+        ]
+      },
+    ]
+  },
+  {
+    name: 'Destinations',
+    sets: [
+      {
+        name: _(
+          'DestinyPlaceDefinition[975684424].displayProperties.name', // Double Check
+          'The Moon' // Double Check
+        ),
+        id: 'year-three-moon',
+        description: _(
+          'DestinyCollectibleDefinition[1350431641].sourceString', // Double Check
+          'Complete activities and earn rank-up packages on the Moon.' // Double Check
+        ),
+        sections: [
+          {
+            name: 'Weapons',
+            season: "K", // Double Check
+            items: [
+              2154059444
+            ]
+          },
+          {
+            name: 'Hunter Armor',
+            season: "K", // Double Check
+            items: [
+
+            ]
+          },
+          {
+            name: 'Titan Armor',
+            season: "K", // Double Check
+            items: [
+
+            ]
+          },
+          {
+            name: 'Warlock Armor',
+            season: "K", // Double Check
+            items: [
+
+            ]
+          },
+          {
+            name: 'Extras',
+            season: "K", // Double Check
+            items: [
+
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    name: 'Holiday & Special Events',
+    sets: [
+      {
+        name: 'Festival of the Lost',
+        id: 'year-three-festival-of-the-lost',
+        description: 'Earned during the seasonal Festival of the Lost event.', // Double Check
+        sections: [
+          {
+            name: 'Weapons',
+            season: 8, // Double Check
+            items: [
+              2154059444
+            ]
+          },
+          {
+            name: 'Hunter Armor',
+            season: 8, // Double Check
+            items: [
+
+            ]
+          },
+          {
+            name: 'Titan Armor',
+            season: 8, // Double Check
+            items: [
+
+            ]
+          },
+          {
+            name: 'Warlock Armor',
+            season: 8, // Double Check
+            items: [
+
+            ]
+          },
+          {
+            name: 'Masks',
+            season: 8, // Double Check
+            items: [
+
+            ]
+          },
+          {
+            name: 'Emotes',
+            season: 8, // Double Check
+            items: [
+
+            ]
+          },
+          {
+            name: 'Ghosts',
+            season: 8, // Double Check
+            items: [
+
+            ]
+          },
+          {
+            name: 'Ghost Projections',
+            season: 8, // Double Check
+            items: [
+
+            ]
+          },
+          {
+            name: 'Sparrows',
+            season: 8, // Double Check
+            items: [
+
+            ]
+          },
+          {
+            name: 'Ships',
+            season: 8, // Double Check
+            items: [
+
+            ]
+          },
+          {
+            name: 'Extras',
+            season: 8, // Double Check
+            items: [
+
+            ]
+          }
+        ]
+      },
+    ]
+  },
+  {
+    name: 'Other',
+    sets: [
+      {
+        name: _(
+          'DestinyVendorDefinition[3163810067].displayProperties.name',
+          'Legendary Engram'
+        ),
+        description: _(
+          'DestinyCollectibleDefinition[256984755].sourceString',
+          'Open Legendary engrams and earn faction rank-up packages.'
+        ),
+        id: 'year-three-legendary-engram',
+        big: false, // Double Check
+        sections: [
+          {
+            name: 'Weapons',
+            season: 4,
+            items: [
+              2154059444
+            ]
+          },
+          {
+            name: 'Hunter Armor',
+            season: 4,
+            itemGroups: [
+              [
+
+              ],
+              [
+
+              ],
+              [
+
+              ]
+            ]
+          },
+          {
+            name: 'Titan Armor',
+            season: 4,
+            itemGroups: [
+              [
+
+              ],
+              [
+
+              ],
+              [
+
+              ]
+            ]
+          },
+          {
+            name: 'Warlock Armor',
+            season: 4,
+            itemGroups: [
+              [
+
+              ],
+              [
+
+              ],
+              [
+
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        name: _(
+          'DestinyFactionDefinition[1393733616].displayProperties.name', // Double Check
+          'Eververse' // Double Check
+        ),
+        id: 'year-three-eververse',
+        description: _(
+          'DestinyCollectibleDefinition[764786884].sourceString', // Double Check
+          'Seasonal Bright Engrams.' // Double Check
+        ),
+        big: false, // Double Check
+        sections: [
+          {
+            name: 'Armor',
+            season: 8, // Double Check
+            itemGroups: [
+              [
+                // Hunter
+                2154059444
+              ],
+              [
+                // Titan
+              ],
+              [
+                // Warlock
+              ]
+            ]
+          },
+          {
+            name: 'Ornaments',
+            season: 8, // Double Check
+            itemGroups: [
+              [
+                // Exotic Weapon
+              ],
+              [
+                // Legendary Weapon
+              ],
+              [
+                // Exotic Armour
+              ]
+            ]
+          },
+          {
+            name: 'Emotes',
+            season: 8, // Double Check
+            items: [
+
+            ]
+          },
+          {
+            name: 'Ghosts',
+            season: 8, // Double Check
+            items: [
+
+            ]
+          },
+          {
+            name: 'Ghost Projections',
+            season: 8, // Double Check
+            items: [
+
+            ]
+          },
+          {
+            name: 'Sparrows',
+            season: 8, // Double Check
+            items: [
+
+            ]
+          },
+          {
+            name: 'Ships',
+            season: 8, // Double Check
+            items: [
+
+            ]
+          },
+          {
+            name: 'Shaders',
+            season: 8, // Double Check
+            items: [
+
+            ]
+          },
+          {
+            name: 'Transmat Effects',
+            season: 8, // Double Check
+            items: [
+
+            ]
+          }
+        ]
+      }
     ]
   }
 ]: SetPage);

--- a/src/setData/yearThree.js
+++ b/src/setData/yearThree.js
@@ -9,117 +9,105 @@ export default ([
     sets: [
       {
         name: _(
-          'DestinyActivityModeDefinition[2394616003].displayProperties.name',
-          'Strikes'
+          'DestinyActivityModeDefinition[2394616003].displayProperties.name', // Double Check
+          'Strikes' // Double Check
         ),
-        id: 'YEAR_TWO_STRIKES',
+        id: 'year-three-strikes',
         description: _(
-          'DestinyCollectibleDefinition[2589931339].sourceString',
-          'Complete strikes and earn rank-up packages from Commander Zavala.'
+          'DestinyCollectibleDefinition[2589931339].sourceString', // Double Check
+          'Complete strikes and earn rank-up packages from Commander Zavala.' // Double Check
         ),
         sections: [
           {
             name: 'Weapons',
-            season: 4,
+            season: "4", // Double Check
             items: [
-              3040742682, // Nameless Midnight
-              2009277538, // The Last Dance
-              2957367743, // Toil and Trouble
-              253196586, // Oath for Tomorrow
-              3745990145, // Long Shadow
-              4146702548 // Outrageous Fortune
-            ]
-          },
-          {
-            name: 'Weapons',
-            season: 5,
-            items: [
-              792755504, // Nightshade
-              4083045006 // Persuader
-            ]
-          },
-          {
-            name: 'Weapons',
-            season: 6,
-            items: [
-              834081972 //  Service Revolver
+
             ]
           },
           {
             name: 'Hunter Armor',
-            season: 4,
+            season: 4, // Double Check
             items: [
-              575676771, // Vigil of Heroes
-              1247181362, // Vigil of Heroes
-              3916064886, // Vigil of Heroes
-              2072877132, // Vigil of Heroes
-              3670149407 // Vigil of Heroes
+
             ]
           },
           {
             name: 'Titan Armor',
-            season: 4,
+            season: 4, // Double Check
             items: [
-              1514863327, // Vigil of Heroes
-              1490307366, // Vigil of Heroes
-              335317194, // Vigil of Heroes
-              1007759904, // Vigil of Heroes
-              506100699 // Vigil of Heroes
+
             ]
           },
           {
             name: 'Warlock Armor',
-            season: 4,
+            season: 4, // Double Check
             items: [
-              3213912958, // Vigil of Heroes
-              2442309039, // Vigil of Heroes
-              3569624585, // Vigil of Heroes
-              2592351697, // Vigil of Heroes
-              1054960580 // Vigil of Heroes
+
             ]
           },
           {
             name: 'Extras',
-            season: 4,
+            season: 4, // Double Check
             items: [
-              2390666069, // High-Risk, High-Reward (Emblem)
-              1075647353, // Vanguard Terminus (Emblem)
-              2935851862, // Struck a Nerve (Emblem)
-              2294983474, // Honor of the Vanguard (Emblem)
-              2294983475, // Strikes of All Stripes (Emblem)
-              1987790789, // After the Nightfall (Emblem)
-              1263710510, // Always North (Shader)
-              2788911999, // Vanguard Veteran (Shader)
-              2788911998, // Vanguard Metallic (Shader)
-              2788911997 // Vanguard Divide (Shader)
-            ]
-          },
-          {
-            name: 'Extras',
-            season: 5,
-            items: [
-              912222548, // Soldier On (Emblem)
-              274843196 // Vanguard Unyielding (Shader)
-            ]
-          },
-          {
-            name: 'Extras',
-            season: 6,
-            items: [
-              3215252549 // Determination
-            ]
-          },
-          {
-            name: 'Extras',
-            season: 7,
-            items: [
-              1661191186, // DISDAIN FOR GOLD
-              2523776413, // VANGUARD STEEL
-              2523776412 // VANGUARD BURNISHED STEEL
+
             ]
           }
         ]
       }
+    ]
+  },
+  {
+    name: 'Destinations',
+    sets: [
+      {
+        name: _(
+          'DestinyPlaceDefinition[975684424].displayProperties.name', // Double Check
+          'The Moon' // Double Check
+        ),
+        id: 'year-three-moon',
+        description: _(
+          'DestinyCollectibleDefinition[1350431641].sourceString', // Double Check
+          'Complete activities and earn rank-up packages on the Moon.' // Double Check
+        ),
+        sections: [
+          {
+            name: 'Weapons',
+            season: "K", // Double Check
+            items: [
+
+            ]
+          },
+          {
+            name: 'Hunter Armor',
+            season: "K", // Double Check
+            items: [
+
+            ]
+          },
+          {
+            name: 'Titan Armor',
+            season: "K", // Double Check
+            items: [
+
+            ]
+          },
+          {
+            name: 'Warlock Armor',
+            season: "K", // Double Check
+            items: [
+
+            ]
+          },
+          {
+            name: 'Extras',
+            season: "K", // Double Check
+            items: [
+
+            ]
+          }
+        ]
+      },
     ]
   }
 ]: SetPage);

--- a/src/setData/yearThree.js
+++ b/src/setData/yearThree.js
@@ -22,7 +22,7 @@ export default ([
             name: 'Weapons',
             season: "K", // Double Check
             items: [
-              2154059444
+
             ]
           },
           {
@@ -178,7 +178,7 @@ export default ([
       //       name: 'Weapons',
       //       season: 8, // Double Check
       //       items: [
-      //         2154059444
+      //         
       //       ]
       //     },
       //     {
@@ -373,7 +373,7 @@ export default ([
   //           name: 'Weapons',
   //           season: 8, // Double Check
   //           items: [
-  //             2154059444
+  //             
   //           ]
   //         },
   //         {
@@ -519,100 +519,100 @@ export default ([
       //     }
       //   ]
       // },
-      {
-        name: _(
-          'DestinyFactionDefinition[1393733616].displayProperties.name', // Double Check
-          'Eververse' // Double Check
-        ),
-        id: 'year-three-eververse',
-        description: _(
-          'DestinyCollectibleDefinition[764786884].sourceString', // Double Check
-          'Seasonal Bright Engrams.' // Double Check
-        ),
-        big: false, // Double Check
-        sections: [
-          {
-            name: 'Armor',
-            season: 8, // Double Check
-            itemGroups: [
-              [
-                // Hunter
-                2154059444
-              ],
-              [
-                // Titan
-              ],
-              [
-                // Warlock
-              ]
-            ]
-          },
-          {
-            name: 'Ornaments',
-            season: 8, // Double Check
-            itemGroups: [
-              [
-                // Exotic Weapon
-              ],
-              [
-                // Legendary Weapon
-              ],
-              [
-                // Exotic Armour
-              ]
-            ]
-          },
-          {
-            name: 'Emotes',
-            season: 8, // Double Check
-            items: [
+      // {
+      //   name: _(
+      //     'DestinyFactionDefinition[1393733616].displayProperties.name', // Double Check
+      //     'Eververse' // Double Check
+      //   ),
+      //   id: 'year-three-eververse',
+      //   description: _(
+      //     'DestinyCollectibleDefinition[764786884].sourceString', // Double Check
+      //     'Seasonal Bright Engrams.' // Double Check
+      //   ),
+      //   big: false, // Double Check
+      //   sections: [
+      //     {
+      //       name: 'Armor',
+      //       season: 8, // Double Check
+      //       itemGroups: [
+      //         [
+      //           // Hunter
 
-            ]
-          },
-          {
-            name: 'Ghosts',
-            season: 8, // Double Check
-            items: [
+      //         ],
+      //         [
+      //           // Titan
+      //         ],
+      //         [
+      //           // Warlock
+      //         ]
+      //       ]
+      //     },
+      //     {
+      //       name: 'Ornaments',
+      //       season: 8, // Double Check
+      //       itemGroups: [
+      //         [
+      //           // Exotic Weapon
+      //         ],
+      //         [
+      //           // Legendary Weapon
+      //         ],
+      //         [
+      //           // Exotic Armour
+      //         ]
+      //       ]
+      //     },
+      //     {
+      //       name: 'Emotes',
+      //       season: 8, // Double Check
+      //       items: [
 
-            ]
-          },
-          {
-            name: 'Ghost Projections',
-            season: 8, // Double Check
-            items: [
+      //       ]
+      //     },
+      //     {
+      //       name: 'Ghosts',
+      //       season: 8, // Double Check
+      //       items: [
 
-            ]
-          },
-          {
-            name: 'Sparrows',
-            season: 8, // Double Check
-            items: [
+      //       ]
+      //     },
+      //     {
+      //       name: 'Ghost Projections',
+      //       season: 8, // Double Check
+      //       items: [
 
-            ]
-          },
-          {
-            name: 'Ships',
-            season: 8, // Double Check
-            items: [
+      //       ]
+      //     },
+      //     {
+      //       name: 'Sparrows',
+      //       season: 8, // Double Check
+      //       items: [
 
-            ]
-          },
-          {
-            name: 'Shaders',
-            season: 8, // Double Check
-            items: [
+      //       ]
+      //     },
+      //     {
+      //       name: 'Ships',
+      //       season: 8, // Double Check
+      //       items: [
 
-            ]
-          },
-          {
-            name: 'Transmat Effects',
-            season: 8, // Double Check
-            items: [
+      //       ]
+      //     },
+      //     {
+      //       name: 'Shaders',
+      //       season: 8, // Double Check
+      //       items: [
 
-            ]
-          }
-        ]
-      }
+      //       ]
+      //     },
+      //     {
+      //       name: 'Transmat Effects',
+      //       season: 8, // Double Check
+      //       items: [
+
+      //       ]
+      //     }
+      //   ]
+      // }
     ]
   }
 ]: SetPage);

--- a/src/setData/yearThree.js
+++ b/src/setData/yearThree.js
@@ -1,0 +1,125 @@
+// @flow
+import type { SetPage } from '../types';
+import * as common from './common';
+import { i18nDefinitionString as _ } from './utils';
+
+export default ([
+  {
+    name: 'Activities',
+    sets: [
+      {
+        name: _(
+          'DestinyActivityModeDefinition[2394616003].displayProperties.name',
+          'Strikes'
+        ),
+        id: 'YEAR_TWO_STRIKES',
+        description: _(
+          'DestinyCollectibleDefinition[2589931339].sourceString',
+          'Complete strikes and earn rank-up packages from Commander Zavala.'
+        ),
+        sections: [
+          {
+            name: 'Weapons',
+            season: 4,
+            items: [
+              3040742682, // Nameless Midnight
+              2009277538, // The Last Dance
+              2957367743, // Toil and Trouble
+              253196586, // Oath for Tomorrow
+              3745990145, // Long Shadow
+              4146702548 // Outrageous Fortune
+            ]
+          },
+          {
+            name: 'Weapons',
+            season: 5,
+            items: [
+              792755504, // Nightshade
+              4083045006 // Persuader
+            ]
+          },
+          {
+            name: 'Weapons',
+            season: 6,
+            items: [
+              834081972 //  Service Revolver
+            ]
+          },
+          {
+            name: 'Hunter Armor',
+            season: 4,
+            items: [
+              575676771, // Vigil of Heroes
+              1247181362, // Vigil of Heroes
+              3916064886, // Vigil of Heroes
+              2072877132, // Vigil of Heroes
+              3670149407 // Vigil of Heroes
+            ]
+          },
+          {
+            name: 'Titan Armor',
+            season: 4,
+            items: [
+              1514863327, // Vigil of Heroes
+              1490307366, // Vigil of Heroes
+              335317194, // Vigil of Heroes
+              1007759904, // Vigil of Heroes
+              506100699 // Vigil of Heroes
+            ]
+          },
+          {
+            name: 'Warlock Armor',
+            season: 4,
+            items: [
+              3213912958, // Vigil of Heroes
+              2442309039, // Vigil of Heroes
+              3569624585, // Vigil of Heroes
+              2592351697, // Vigil of Heroes
+              1054960580 // Vigil of Heroes
+            ]
+          },
+          {
+            name: 'Extras',
+            season: 4,
+            items: [
+              2390666069, // High-Risk, High-Reward (Emblem)
+              1075647353, // Vanguard Terminus (Emblem)
+              2935851862, // Struck a Nerve (Emblem)
+              2294983474, // Honor of the Vanguard (Emblem)
+              2294983475, // Strikes of All Stripes (Emblem)
+              1987790789, // After the Nightfall (Emblem)
+              1263710510, // Always North (Shader)
+              2788911999, // Vanguard Veteran (Shader)
+              2788911998, // Vanguard Metallic (Shader)
+              2788911997 // Vanguard Divide (Shader)
+            ]
+          },
+          {
+            name: 'Extras',
+            season: 5,
+            items: [
+              912222548, // Soldier On (Emblem)
+              274843196 // Vanguard Unyielding (Shader)
+            ]
+          },
+          {
+            name: 'Extras',
+            season: 6,
+            items: [
+              3215252549 // Determination
+            ]
+          },
+          {
+            name: 'Extras',
+            season: 7,
+            items: [
+              1661191186, // DISDAIN FOR GOLD
+              2523776413, // VANGUARD STEEL
+              2523776412 // VANGUARD BURNISHED STEEL
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]: SetPage);

--- a/src/setData/yearThree.js
+++ b/src/setData/yearThree.js
@@ -7,54 +7,54 @@ export default ([
   {
     name: 'Activities',
     sets: [
-      {
-        name: _(
-          'DestinyActivityModeDefinition[2394616003].displayProperties.name', // Double Check
-          'Strikes' // Double Check
-        ),
-        id: 'year-three-strikes',
-        description: _(
-          'DestinyCollectibleDefinition[2589931339].sourceString', // Double Check
-          'Complete strikes and earn rank-up packages from Commander Zavala.' // Double Check
-        ),
-        sections: [
-          {
-            name: 'Weapons',
-            season: "K", // Double Check
-            items: [
+      // {
+      //   name: _(
+      //     'DestinyActivityModeDefinition[2394616003].displayProperties.name', // Double Check
+      //     'Strikes' // Double Check
+      //   ),
+      //   id: 'year-three-strikes',
+      //   description: _(
+      //     'DestinyCollectibleDefinition[2589931339].sourceString', // Double Check
+      //     'Complete strikes and earn rank-up packages from Commander Zavala.' // Double Check
+      //   ),
+      //   sections: [
+      //     {
+      //       name: 'Weapons',
+      //       season: "K", // Double Check
+      //       items: [
 
-            ]
-          },
-          {
-            name: 'Hunter Armor',
-            season: "K", // Double Check
-            items: [
+      //       ]
+      //     },
+      //     {
+      //       name: 'Hunter Armor',
+      //       season: "K", // Double Check
+      //       items: [
 
-            ]
-          },
-          {
-            name: 'Titan Armor',
-            season: "K", // Double Check
-            items: [
+      //       ]
+      //     },
+      //     {
+      //       name: 'Titan Armor',
+      //       season: "K", // Double Check
+      //       items: [
 
-            ]
-          },
-          {
-            name: 'Warlock Armor',
-            season: "K", // Double Check
-            items: [
+      //       ]
+      //     },
+      //     {
+      //       name: 'Warlock Armor',
+      //       season: "K", // Double Check
+      //       items: [
 
-            ]
-          },
-          {
-            name: 'Extras',
-            season: "K", // Double Check
-            items: [
+      //       ]
+      //     },
+      //     {
+      //       name: 'Extras',
+      //       season: "K", // Double Check
+      //       items: [
 
-            ]
-          }
-        ]
-      },
+      //       ]
+      //     }
+      //   ]
+      // },
       {
         name: _(
           'DestinyActivityModeDefinition[1164760504].displayProperties.name', // Double Check

--- a/src/setData/yearThree.js
+++ b/src/setData/yearThree.js
@@ -154,7 +154,7 @@ export default ([
         sections: [
           {
             name: 'Extras',
-            season: "K",
+            // season: "K",
             items: [
               298334057 // A Sibyl's Dreams
             ]
@@ -222,7 +222,7 @@ export default ([
         sections: [
           {
             name: 'Weapons',
-            season: "K", // Double Check
+            // season: "K", // Double Check
             items: [
               // 3385326721, // Reckless Oracle
               // 2408405461, // Sacred Provenance
@@ -235,7 +235,7 @@ export default ([
           },
           {
             name: 'Hunter Armor',
-            season: "K", // Double Check
+            // season: "K", // Double Check
             items: [
               // 1399922251, // Cowl of Righteousness
               // 1653741426, // Grips of Exaltation
@@ -246,7 +246,7 @@ export default ([
           },
           {
             name: 'Titan Armor',
-            season: "K", // Double Check
+            // season: "K", // Double Check
             items: [
               // 519078295, // Helm of Righteousness
               // 3887559710, // Gauntlets of Exaltation
@@ -257,7 +257,7 @@ export default ([
           },
           {
             name: 'Warlock Armor',
-            season: "K", // Double Check
+            // season: "K", // Double Check
             items: [
               // 3001934726, // Mask of Righteousness
               // 2015894615, // Gloves of Exaltation
@@ -268,7 +268,7 @@ export default ([
           },
           {
             name: 'Extras',
-            season: "K", // Double Check
+            // season: "K", // Double Check
             items: [
               // 298334059, // Inherent Truth
               // 3996862462, // Ancient Believer 
@@ -295,7 +295,7 @@ export default ([
         sections: [
           {
             name: 'Weapons',
-            season: "K",
+            // season: "K",
             items: [
               2723909519, // Arc Logic
               208088207, // Premonition
@@ -311,7 +311,7 @@ export default ([
           },
           {
             name: 'Hunter Armor',
-            season: "K",
+            // season: "K",
             items: [
               659922705, // Dreambane Cowl
               3571441640, // Dreambane Grips
@@ -322,7 +322,7 @@ export default ([
           },
           {
             name: 'Titan Armor',
-            season: "K",
+            // season: "K",
             items: [
               272413517, // Dreambane Helm
               925079356, // Dreambane Gauntlets
@@ -333,7 +333,7 @@ export default ([
           },
           {
             name: 'Warlock Armor',
-            season: "K",
+            // season: "K",
             items: [
               1528483180, // Dreambane Hood
               682780965, // Dreambane Gloves
@@ -344,7 +344,7 @@ export default ([
           },
           {
             name: 'Extras',
-            season: "K",
+            // season: "K",
             items: [
               1272828316, // Moonshot Shell
               3382260610, // Moonrider One

--- a/src/setData/yearThree.js
+++ b/src/setData/yearThree.js
@@ -210,10 +210,8 @@ export default ([
       //   ]
       // },
       {
-        name: _(
-          // 'DestinyActivityModeDefinition[2394616003].displayProperties.name', // Double Check
-          'Garden of Salvation'
-        ),
+        name: // 'DestinyActivityModeDefinition[2394616003].displayProperties.name', // Double Check
+          'Garden of Salvation', // Add above back in later
         id: 'year-three-garden-of-salvation',
         description: _(
           'DestinyCollectibleDefinition[2948134329].sourceString',
@@ -224,55 +222,55 @@ export default ([
             name: 'Weapons',
             // season: "K", // Double Check
             items: [
-              // 3385326721, // Reckless Oracle
-              // 2408405461, // Sacred Provenance
-              // 48643186, // Ancient Gospel
-              // 4095896073, // Accrued Redemption
-              // 4020742303, // Prophet of Doom
-              // 2209003210, // Zealot's Reward
-              // 3454326177 // Omniscient Eye
+              3385326721, // Reckless Oracle
+              2408405461, // Sacred Provenance
+              48643186, // Ancient Gospel
+              4095896073, // Accrued Redemption
+              4020742303, // Prophet of Doom
+              2209003210, // Zealot's Reward
+              3454326177 // Omniscient Eye
             ]
           },
           {
             name: 'Hunter Armor',
             // season: "K", // Double Check
             items: [
-              // 1399922251, // Cowl of Righteousness
-              // 1653741426, // Grips of Exaltation
-              // 4177973942, // Vest of Transcendence
-              // 2054979724, // Strides of Ascendancy 
-              // 3549177695 // Cloak of Temptation
+              557676195, // Cowl of Righteousness
+              1653741426, // Grips of Exaltation
+              4177973942, // Vest of Transcendence
+              2054979724, // Strides of Ascendancy 
+              3549177695 // Cloak of Temptation
             ]
           },
           {
             name: 'Titan Armor',
             // season: "K", // Double Check
             items: [
-              // 519078295, // Helm of Righteousness
-              // 3887559710, // Gauntlets of Exaltation
-              // 3939809874, // Plate of Transcendence
-              // 11974904, // Greaves of Ascendancy
-              // 281660259 // Temptation's Mark
+              519078295, // Helm of Righteousness
+              3887559710, // Gauntlets of Exaltation
+              3939809874, // Plate of Transcendence
+              11974904, // Greaves of Ascendancy
+              281660259 // Temptation's Mark
             ]
           },
           {
             name: 'Warlock Armor',
             // season: "K", // Double Check
             items: [
-              // 3001934726, // Mask of Righteousness
-              // 2015894615, // Gloves of Exaltation
-              // 2320830625, // Robes of Transcendence
-              // 3824429433, // Boots of Ascendancy
-              // 3103335676 // Temptation's Bond
+              3001934726, // Mask of Righteousness
+              2015894615, // Gloves of Exaltation
+              2320830625, // Robes of Transcendence
+              3824429433, // Boots of Ascendancy
+              3103335676 // Temptation's Bond
             ]
           },
           {
             name: 'Extras',
             // season: "K", // Double Check
             items: [
-              // 298334059, // Inherent Truth
-              // 3996862462, // Ancient Believer 
-              // 3996862463 // Ancient Defender
+              298334059, // Inherent Truth
+              3996862462, // Ancient Believer 
+              3996862463 // Ancient Defender
             ]
           }
         ]

--- a/src/setData/yearTwo.js
+++ b/src/setData/yearTwo.js
@@ -27,7 +27,7 @@ export default ([
               2957367743, // Toil and Trouble
               253196586, // Oath for Tomorrow
               3745990145, // Long Shadow
-              4146702548 // Outrageous Fortune
+              4146702548 // Outrageous Fortunes
             ]
           },
           {

--- a/src/setData/yearTwo.js
+++ b/src/setData/yearTwo.js
@@ -27,7 +27,7 @@ export default ([
               2957367743, // Toil and Trouble
               253196586, // Oath for Tomorrow
               3745990145, // Long Shadow
-              4146702548 // Outrageous Fortunes
+              4146702548 // Outrageous Fortune
             ]
           },
           {

--- a/src/setData/yearTwo.js
+++ b/src/setData/yearTwo.js
@@ -35,14 +35,23 @@ export default ([
             season: 5,
             items: [
               792755504, // Nightshade
-              4083045006 // Persuader
+              4083045006, // Persuader
+              580961571 // Loaded Question
             ]
           },
           {
             name: 'Weapons',
             season: 6,
             items: [
-              834081972 //  Service Revolver
+              834081972, //  Service Revolver
+              3907337522 // Oxygen SR3
+            ]
+          },
+          {
+            name: 'Weapons',
+            season: 7,
+            items: [
+              578459533 // Wendigo GL3
             ]
           },
           {
@@ -140,7 +149,9 @@ export default ([
               3222518097, // Anonymous Autumn
               1684914716, // Fate Cries Foul
               4230993599, // Steel Sybil Z-14
-              195440257 // Play of the Game
+              195440257, // Play of the Game
+              153979396, // Luna's Howl
+              1161276682 // Redrix's Broadsword 
             ]
           },
           {
@@ -148,14 +159,23 @@ export default ([
             season: 5,
             items: [
               3356526253, // Wishbringer
-              2278995296 // Does Not Compute
+              2278995296, // Does Not Compute
+              3993415705 // The Mountaintop
             ]
           },
           {
             name: 'Weapons',
             season: 6,
             items: [
-              188882152 // Last Perdition
+              188882152, // Last Perdition
+              3354242550 // The Recluse
+            ]
+          },
+          {
+            name: 'Weapons',
+            season: 7,
+            items: [
+              654608616 // Revoker
             ]
           },
           {
@@ -257,6 +277,20 @@ export default ([
             ]
           },
           {
+            name: 'Weapons',
+            season: 5,
+            items: [
+              324382200 // Breakneck
+            ]
+          },
+          {
+            name: 'Weapons',
+            season: 6,
+            items: [
+              1600633250 // 21% Delirium
+            ]
+          },
+          {
             name: 'Prime Weapons',
             season: 6,
             items: [
@@ -267,6 +301,13 @@ export default ([
               2199171672, // Lonesome
               1115104187, //  Sole Survivor
               2744715540 // Bug-Out Bag
+            ]
+          },
+          {
+            name: 'Weapons',
+            season: 7,
+            items: [
+              1584643826 // Hush
             ]
           },
           {

--- a/src/views/Inventory/selectors.js
+++ b/src/views/Inventory/selectors.js
@@ -10,12 +10,12 @@ import {
   WEAPON_MODS_ORNAMENTS,
   ARMOR_MODS_ORNAMENTS,
   FILTER_SHOW_COLLECTED,
-  FILTER_SHOW_PS4_EXCLUSIVES,
+  // FILTER_SHOW_PS4_EXCLUSIVES,
   FILTER_SHOW_HIDDEN_SETS,
   FILTER_SHOW_ORNAMENTS,
   FILTER_SHOW_WEAPONS
 } from 'app/lib/destinyEnums';
-import CONSOLE_EXCLUSIVES from 'app/extraData/consoleExclusives';
+// import CONSOLE_EXCLUSIVES from 'app/extraData/consoleExclusives';
 
 import {
   inventorySelector,
@@ -72,12 +72,12 @@ function filterItem(item, inventory, filters, searchTerm) {
     return false;
   }
 
-  if (
-    !filters[FILTER_SHOW_PS4_EXCLUSIVES] &&
-    CONSOLE_EXCLUSIVES.ps4.includes(item.hash)
-  ) {
-    return false;
-  }
+  // if (
+  //   !filters[FILTER_SHOW_PS4_EXCLUSIVES] &&
+  //   CONSOLE_EXCLUSIVES.ps4.includes(item.hash)
+  // ) {
+  //   return false;
+  // }
 
   if (!filters[FILTER_SHOW_COLLECTED] && inventory) {
     const inventoryEntry = inventory[item.hash];


### PR DESCRIPTION
- Commented out PS4 Exclusives
- Shadowkeep Items
- Season 8 Items

- Started Eververse, only put the items up for Bright Dust currently.

Might be items missing, but it's a start. Tried adding "K", (Shadowkeep for short (SK)) as a season number, ran fine perfectly locally but threw up errors here. Just wanted to show the difference between Seasonal & Shadowkeep content. Maybe if number, show "Season #", if text parsed show "Text". Probably easier said than done.

Now back to playing 🙂