### PR TITLE
Fix Braytech Werewolf

### DIFF
--- a/src/setData/yearThree.js
+++ b/src/setData/yearThree.js
@@ -372,7 +372,7 @@ export default ([
             name: 'Weapons',
             season: 8,
             items: [
-                3645283765 // Braytech Werewolf
+                528834068 // Braytech Werewolf
             ]
           },
           {


### PR DESCRIPTION
I think this is the correct item hash for the Braytech Werewolf? I think the other one is like a psuedo-item that a vendor sells, that will then drop this item. I think.