### PR TITLE
`The Shattered Throne`, The Moon, Crimson Days & Eververse

### DIFF
--- a/src/setData/yearThree.js
+++ b/src/setData/yearThree.js
@@ -1220,7 +1220,7 @@ export default ([
                 3654808012, // The Fourteenth Anamnesis
                 3786758103, // Embodiment of the Warbeast
                 3778646768, // Flight of the Interceptor
-                475012491 // The Want of Lies and Wishes
+                // 475012491 // The Want of Lies and Wishes (Didn't show up for Bright Dust due to an in-game issue)
               ]
             ]
           },

--- a/src/setData/yearThree.js
+++ b/src/setData/yearThree.js
@@ -917,7 +917,8 @@ export default ([
             name: "Sparrows",
             season: 9,
             items: [
-              1266122672 // IVC-10
+              1266122672, // IVC-10
+              2048941953 // SVC-12
             ]
           },
           {

--- a/src/setData/yearThree.js
+++ b/src/setData/yearThree.js
@@ -515,42 +515,6 @@ export default ([
             ]
           },
           {
-            name: "Nightmare Hunts",
-            // season: "K",
-            items: [
-              298334057, // A Sibyl's Dreams
-              2056256564 // Lunar Halcyon Gilt
-            ]
-          },
-          {
-            name: "Altars of Sorrow",
-            // season: "K",
-            itemGroups: [
-              [
-                2782847179, // Blasphemer (Shotgun)
-                2164448701, // Apostate (Sniper Rifle)
-                3067821200 // Heretic (Rocket Launcher)
-              ],
-              [
-                3708784304 // Bane of Crota Shell (Ghost Shell)
-              ]
-            ]
-          },
-          {
-            name: "'Pit of Heresy' Dungeon",
-            // season: "K",
-            itemGroups: [
-              [
-                208088207 // Premonition (Dungeon Pulse)
-              ],
-              [
-                4023500750, // Bane of Tyrants (Ship)
-                298334061, // Sanguine Static (Emblem)
-                298334060 // Crimson Echoes (Emblem)
-              ]
-            ]
-          },
-          {
             name: "Hunter Armor",
             // season: "K",
             items: [
@@ -581,6 +545,42 @@ export default ([
               3692187003, // Dreambane Robes
               1030110631, // Dreambane Boots
               2048903186 // Dreambane Bond
+            ]
+          },
+          {
+            name: "Altars of Sorrow",
+            // season: "K",
+            itemGroups: [
+              [
+                2782847179, // Blasphemer (Shotgun)
+                2164448701, // Apostate (Sniper Rifle)
+                3067821200 // Heretic (Rocket Launcher)
+              ],
+              [
+                3708784304 // Bane of Crota Shell (Ghost Shell)
+              ]
+            ]
+          },
+          {
+            name: "Nightmare Hunts",
+            // season: "K",
+            items: [
+              298334057, // A Sibyl's Dreams
+              2056256564 // Lunar Halcyon Gilt
+            ]
+          },
+          {
+            name: "'Pit of Heresy' Dungeon",
+            // season: "K",
+            itemGroups: [
+              [
+                208088207 // Premonition (Dungeon Pulse)
+              ],
+              [
+                4023500750, // Bane of Tyrants (Ship)
+                298334061, // Sanguine Static (Emblem)
+                298334060 // Crimson Echoes (Emblem)
+              ]
             ]
           },
           {

--- a/src/setData/yearTwo.js
+++ b/src/setData/yearTwo.js
@@ -1350,13 +1350,21 @@ export default ([
             ]
           },
           {
+            name: 'The Shattered Throne Dungeon',
+            season: 4,
+            items: [
+              814876684, // Wish-Ender
+              2844014413, // Pallas Galliot
+              185321778 // The Eternal Return
+            ]
+          },
+          {
             name: 'Extras',
             season: 4,
             items: [
               813936739, // Starlight Shell
               1317468652, // Harbinger's Echo
               1317468653, // Silver Tercel
-              2844014413, // Pallas Galliot
               3352019292, // Secret Victories
               3118323620, // Drink at the Well
               3118323621, // Transcendent

--- a/src/setData/yearTwo.js
+++ b/src/setData/yearTwo.js
@@ -1359,12 +1359,24 @@ export default ([
             ]
           },
           {
+            name: 'Ascendant Challenges',
+            season: 4,
+            items: [
+              813936739 // Starlight Shell
+            ]
+          },
+          {
+            name: 'Petra Weekly Mission',
+            season: 4,
+            items: [
+              1317468653 // Silver Tercel
+            ]
+          },
+          {
             name: 'Extras',
             season: 4,
             items: [
-              813936739, // Starlight Shell
               1317468652, // Harbinger's Echo
-              1317468653, // Silver Tercel
               3352019292, // Secret Victories
               3118323620, // Drink at the Well
               3118323621, // Transcendent

--- a/src/setData/yearTwo.js
+++ b/src/setData/yearTwo.js
@@ -1350,7 +1350,7 @@ export default ([
             ]
           },
           {
-            name: 'The Shattered Throne Dungeon',
+            name: "'The Shattered Throne' Dungeon",
             season: 4,
             items: [
               814876684, // Wish-Ender


### PR DESCRIPTION
- Hide Skull of Dire Ahamkara Ornament until Bungie fixes issue of it not appearing for Bright Dust
- Added `The Shattered Throne` Dungeon to Dreaming City
- Re-ordered The Moon items
- Added another Crimson Days Sparrow