### PR TITLE
Adding Mnemonic Engram (Season 11) definitions

### DIFF
--- a/src/setData/yearThree.js
+++ b/src/setData/yearThree.js
@@ -2441,6 +2441,174 @@ export default ([
             ]
           }
         ]
+      },
+      {
+        name: _(
+          'DestinyVendorDefinition[3767535285].displayProperties.name',
+          'Mnemonic Engram'
+        ),
+        id: 'season-11-mnemonic-engram',
+        description: _(
+          'DestinyInventoryItemDefinition[3692259864].displayProperties.description',
+          'An engram containing different ornaments, emotes, and accessories from previous Destiny 2 releases.'
+        ),
+        big: true,
+        sections: [
+          {
+            name: 'Ornaments',
+            season: 11,
+            items: [
+              2110420504, // "Down to Business"
+              3034617041, // "Jade Countenance"
+              2599526136, // "Catacombs"
+              2425317590, // "Positive Infinity"
+              3779623011, // "Lethal System"
+              346961818,  // "IKELOS Field Tuning"
+              3838841051, // "Ultraviolet"
+              3093486579, // "Sky/Perdition"
+              2744195002, // "Third Rail"
+              2020179519, // "Polemology"
+              135999390,  // "Past Is Past"
+              451772823,  // "Foretelling"
+              4150423078, // "Unwelcome Visit"
+              2812946864, // "At Any Cost"
+              1414396215, // "Itsy-Bitsy Spider"
+              403561732,  // "Defenseless, to Be Armed"
+              3473397300, // "King in All Directions"
+              1145663134, // "Great White"
+              3628276006, // "Thundergod"
+              3624790844, // "Eerie Breeze"
+              933468683,  // "Grant's Vicksburg"
+              3200402431, // "Bronze Carapace"
+              2173197096, // "A Stride to the Edge"
+              2406427719 // "Conflux Control"
+            ]
+          },
+          {
+            name: 'Ghost Shells',
+            season: 11,
+            items: [
+              1558857470, // "Star Map Shell"
+              443190217,  // "Kitbash Shell"
+              779216204,  // "Harper's Shell"
+              779216201,  // "Scarlet Swarm Shell"
+              261110024,  // "Bold Shell"
+              261110022,  // "Interchange Shell"
+              277887715,  // "Hemisphere Shell"
+              277887712,  // "Aggressive Shell"
+              89965910,   // "Kaleidoscope Shell"
+              89965911,   // "In Fine Omnium Shell"
+              89965918,   // "Orchid Shell"
+              89965919,   // "Yellowspear Shell"
+              1271045317, // "Infinite Blue Shell"
+              1271045316, // "Garter Snake Shell"
+              1748063012, // "Palm of Gold Shell"
+              1748063015, // "Waiting Cask Shell"
+              374922800,  // "Cordial Diamond Shell"
+              374922801,  // "Trusty Shell"
+              374922810,  // "Spectral Circuit Shell"
+              374922811,  // "Eyeball Shell"
+              2371653990, // "Tastemaker Shell"
+              2371653991 // "Worrier Shell"
+            ]
+          },
+          {
+            name: 'Emotes',
+            season: 11,
+            items: [
+              421712807,  // "Mic Drop"
+              717948749,  // "Sweeping"
+              1863079869, // "Red Card"
+              2272950849, // "Chicken Dinner"
+              3470992439, // "Guitar Solo"
+              2291520183, // "Ninja Vanish"
+              267290351,  // "Flowing Dance"
+              159967058,  // "Hold On"
+              1471723144, // "Confused"
+              319183094,  // "Meditative Moment"
+              3105326202, // "Cross-Step Shuffle"
+              1188569234, // "Ding"
+              2541494210, // "You're the Guardian"
+              1073496778, // "Opulent Clap"
+              896553940,  // "Lucky Shot"
+              4179243516, // "Time Out"
+              248592690,  // "Eat It Up"
+              3702002191 // "Be Sneaky"
+            ]
+          },
+          {
+            name: 'Sparrows',
+            season: 11,
+            items: [
+              3268592503, // "The Bronco"
+              258623693,  // "The Calypso"
+              2067296769, // "Blood Runner"
+              2067296773, // "Four Degrees of Separation"
+              2546958593, // "October Dash"
+              2546958592, // "Sagittarius"
+              3889183912, // "Athwart the Void"
+              3889183906, // "Chronoglass"
+              3538153288, // "Tropidon V"
+              3538153289, // "Velos Knight"
+              3610177558, // "Soul Sylph"
+              3610177553, // "Striped Abandon"
+              3538153285, // "Sharklight"
+              3588486148, // "Machina Macro"
+              2351197438, // "Mindbarge"
+              2351197439, // "Fiery Phoenician"
+              2285214171, // "Thermal Runaway"
+              2285214168, // "Endymion Cavalcade"
+              4085575831, // "Where I Belong"
+              4085575830, // "Gravity Maestro"
+              3330250540, // "Sunny Disposition"
+              3330250541 // "Aerolite HW-42"
+            ]
+          },
+          {
+            name: 'Ships',
+            season: 11,
+            items: [
+              292872939,  // "Asher Mir's One-Way Ticket"
+              2417017738, // "Ódrerir"
+              2964059919, // "The Oviraptor"
+              4079130217, // "Quality Cut"
+              4209989372, // "Dead Fall"
+              4209989373, // "Sojourner"
+              2503134036, // "Shadowed Dawn"
+              2503134042, // "Helios Strain"
+              658724913,  // "Runereed"
+              658724914,  // "Wanderlonging"
+              530012777,  // "Nebula Bloom"
+              530012776,  // "Rubente Dextra"
+              1833943247, // "Pitfall Souter E5D"
+              1833943245, // "Dusk Harrier"
+              3600237174, // "Bicameral Promise"
+              3600237175, // "Last Sunset"
+              3941922388, // "The People's Pride"
+              3941922389, // "Technical Meltdown"
+              4063523621, // "Broadcast-IS"
+              4063523618, // "Egbe-01X"
+              4063523630, // "DSV-Huygens IX"
+              4063523631 // "SCRAP MS-123-88"
+            ]
+          },
+          {
+            name: 'Ghost Projections',
+            season: 11,
+            items: [
+              1295682249, // "Crown of Sorrow Projection"
+              1295682248, // "Emperor Calus Projection"
+              2155593794, // "Moonbound Projection"
+              2155593795, // "Mindjack Projection"
+              1927164028, // "Electrostatic Projection"
+              3148574220, // "Häkke Projection"
+              2233846232, // "Clashing Projection"
+              668465167,  // "Twin Snake Projection"
+              3527564903, // "Treasure Chest Projection"
+              3527564896 // "Salacot Projection"
+            ]
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
Should make it easier to check if someone (me) is missing something from the engram drops. I didn't do the Shaders or Transmats because:

1. It's a lot
2. I'm not confident it limits itself to those.

Did my best to emulate the configuration file, may have gotten somethings wrong.